### PR TITLE
Image get from cache only

### DIFF
--- a/lib/cached_network_image.dart
+++ b/lib/cached_network_image.dart
@@ -496,7 +496,13 @@ class CachedNetworkImageProvider
       throw new Exception("File was empty");
     }
 
-    return await ui.instantiateImageCodec(bytes);
+    Future<ui.Codec> codecF = ui.instantiateImageCodec(bytes)
+      ..catchError((e){
+        if (errorListener != null) errorListener();
+        throw new Exception("File not a valid Image");
+      });
+
+    return codecF;
   }
 
   @override

--- a/lib/cached_network_image.dart
+++ b/lib/cached_network_image.dart
@@ -34,16 +34,16 @@ class CachedNetworkImage extends StatefulWidget {
     this.placeholder,
     @required this.imageUrl,
     this.errorWidget,
-    this.fadeOutDuration: const Duration(milliseconds: 300),
-    this.fadeOutCurve: Curves.easeOut,
-    this.fadeInDuration: const Duration(milliseconds: 700),
-    this.fadeInCurve: Curves.easeIn,
+    this.fadeOutDuration = const Duration(milliseconds: 300),
+    this.fadeOutCurve = Curves.easeOut,
+    this.fadeInDuration = const Duration(milliseconds: 700),
+    this.fadeInCurve = Curves.easeIn,
     this.width,
     this.height,
     this.fit,
     this.alignment: Alignment.center,
     this.repeat: ImageRepeat.noRepeat,
-    this.matchTextDirection: false,
+    this.matchTextDirection = false,
     this.httpHeaders,
   })  : assert(imageUrl != null),
         assert(fadeOutDuration != null),
@@ -434,7 +434,7 @@ class CachedNetworkImageProvider
   /// Creates an ImageProvider which loads an image from the [url], using the [scale].
   /// When the image fails to load [errorListener] is called.
   const CachedNetworkImageProvider(this.url,
-      {this.scale: 1.0, this.errorListener, this.headers})
+      {this.scale = 1.0, this.errorListener, this.headers})
       : assert(url != null),
         assert(scale != null);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_cache_manager: ^0.1.2
+  #flutter_cache_manager: ^0.1.2
+  flutter_cache_manager:
+    git:
+      url: git://github.com/rmarau/flutter_cache_manager.git
 
 dev_dependencies:
   test: ^1.3.0


### PR DESCRIPTION
New feature: Adds the possibility to show the image only if it is cached - skips the network download. 

Bug fix: When an image is not valid (the codec fails), the errorWidget was not replacing the placeholder.

Also Fixes a deprecation warning from dart2.
