### PR TITLE
Use https://github.com/Cretezy/flutter_cache_manager.git to work with flutter v0.6.0.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_cache_manager: "^0.1.1"
+  flutter_cache_manager:
+    git: https://github.com/Cretezy/flutter_cache_manager.git
 
 dev_dependencies:
   test: ^0.12.0


### PR DESCRIPTION
Use https://github.com/Cretezy/flutter_cache_manager.git to work with flutter v0.6.0.