### PR TITLE
Moving StreamBuilder to FutureBuilder - Fixing  #144

### DIFF
--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -259,7 +259,7 @@ class CachedNetworkImageState extends State<CachedNetworkImage>
       initialData: _fileCache[widget.imageUrl],
       future: _cacheManager()
           .getFile(widget.imageUrl, headers: widget.httpHeaders)
-          /// This 'where' filter is pointless. It's not saving much because FileInfo
+          /// This 'where' filter becomes pointless. It's not saving much because FileInfo
           /// is already loaded from cache/network.
           /// Filtering the result to the future results in a StateError passed down to snapshot.error
           /// We could have some logic in the builder, but again, we're not saving much. 
@@ -325,7 +325,7 @@ class CachedNetworkImageState extends State<CachedNetworkImage>
     );
   }
 
-  BaseCacheManager _cacheManager() {
+  _cacheManager() {
     return widget.cacheManager ?? DefaultCacheManager();
   }
 

--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -259,9 +259,14 @@ class CachedNetworkImageState extends State<CachedNetworkImage>
       initialData: _fileCache[widget.imageUrl],
       future: _cacheManager()
           .getFile(widget.imageUrl, headers: widget.httpHeaders)
-          .firstWhere((f) =>
-              f?.originalUrl != _fileCache[widget.imageUrl]?.originalUrl ||
-              f?.validTill != _fileCache[widget.imageUrl]?.validTill),
+          /// This 'where' filter is pointless. It's not saving much because FileInfo
+          /// is already loaded from cache/network.
+          /// Filtering the result to the future results in a StateError passed down to snapshot.error
+          /// We could have some logic in the builder, but again, we're not saving much. 
+          // .where((f) =>
+          //     f?.originalUrl != _fileCache[widget.imageUrl]?.originalUrl ||
+          //     f?.validTill != _fileCache[widget.imageUrl]?.validTill )
+          .first,
       builder: (BuildContext context, AsyncSnapshot<FileInfo> snapshot) {
         if (snapshot.hasError) {
           // error
@@ -320,7 +325,7 @@ class CachedNetworkImageState extends State<CachedNetworkImage>
     );
   }
 
-  _cacheManager() {
+  BaseCacheManager _cacheManager() {
     return widget.cacheManager ?? DefaultCacheManager();
   }
 

--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -254,12 +254,12 @@ class CachedNetworkImageState extends State<CachedNetworkImage>
   }
 
   _animatedWidget() {
-    return StreamBuilder<FileInfo>(
+    return FutureBuilder<FileInfo>(
       key: _streamBuilderKey,
       initialData: _fileCache[widget.imageUrl],
-      stream: _cacheManager()
+      future: _cacheManager()
           .getFile(widget.imageUrl, headers: widget.httpHeaders)
-          .where((f) =>
+          .firstWhere((f) =>
               f?.originalUrl != _fileCache[widget.imageUrl]?.originalUrl ||
               f?.validTill != _fileCache[widget.imageUrl]?.validTill),
       builder: (BuildContext context, AsyncSnapshot<FileInfo> snapshot) {


### PR DESCRIPTION

Is this patch I'm proposing a move from a StreamBuilder Widget to FutureBuilder.
No1 reason: Downloading an image is a one-shot event, not a stream.

(I might be missing some argument to have the StreamBuilder, though)
 There could be the case that in a scenario with a list of images, having a stream helps preserving download in the background. In my testings scrolling up and down was always re-calling `getFile` and doing to the network if not yet in cache.

I came to dig on this because of #144. I suspect that the anomalies described here are a result of using a StreamBuilder. 
What I observed with the current StreamBuilder version:
- In a list with an http 404  image. If we wait time enough to signal the error, everything looks great and the 404 error is absorbed by the network manager that trows it back to the StreamBuilder that will present the errorWidget.
- When we scroll back and forth, faster than the network turnaround time with the 404 from the server: There's a pending download and a new one going through when the widget is re-built. Now, it seems to me (really not sure) the Stream builder unplugs (cancels/interrupts/disposes I didnt check deeper) the stream with the ongoing download and plugs a new stream. Eventually the pending 404 error arrives and the old stream (maybe orphaned) doesn't know where to place the exception, resulting in the Uncaught exception described in #144 . 

What I did very simply was to take the tip of the stream and make it a future.
It was a minimal change. A deeper refactor is needed if to move the whole network manager from Stream oriented approach to Futures.





