### PR TITLE
Restrict Flutter version to < 1.10.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ homepage: https://github.com/renefloor/flutter_cached_network_image
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  flutter: "<1.10.15-pre.148"
 
 dependencies:
   flutter:


### PR DESCRIPTION
1.x versions of this library are incompatible with Flutter versions greater than 1.10.0, due to the upstream changes to ImageProvider.

This PR adds Flutter version constraints to pubspec.yml. This means that users of this library will see an error when attempting to install the package:

> The current Flutter SDK version is 1.12.10.
> 
> Because example depends on cached_network_image from path which requires Flutter SDK version <1.10.0, version solving failed

Which is better than the current behaviour, where the application fails to compile with an obscure compiler error.

The `develop` branch already has constraints to only install with newer versions of Flutter. So this PR is for the existing 1.x branch