### PR TITLE
Catch codec error

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:bitmap/bitmap.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -156,21 +156,34 @@ class _MyHomePageState extends State<MyHomePage> {
             _sizedContainer(
               CachedNetworkImage(
                 imageUrl: 'https://flutter.dev/',
-                placeholder: (context, url) => const CircularProgressIndicator(),
-                errorWidget: (context, url, error) => const Icon(Icons.error),
+                placeholder: (context, url) =>
+                    const CircularProgressIndicator(),
+                errorWidget: (context, url, error) {
+                  return Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(Icons.error),
+                      Text('$error'),
+                    ],
+                  );
+                },
               ),
             ),
             _sizedContainer(
-              _downloadLargeImage ?
-                CachedNetworkImage(
-                  imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/3/3f/Fronalpstock_big.jpg',
-                  placeholder: (context, url) => const CircularProgressIndicator(),
-                  errorWidget: (context, url, error) => const Icon(Icons.error),
-                ) :
-                FlatButton(
-                  child: const Text('Tap to download a large image'),
-                  onPressed: () => setState(() => _downloadLargeImage = true),
-                ),
+              _downloadLargeImage
+                  ? CachedNetworkImage(
+                      imageUrl:
+                          'https://upload.wikimedia.org/wikipedia/commons/3/3f/Fronalpstock_big.jpg',
+                      placeholder: (context, url) =>
+                          const CircularProgressIndicator(),
+                      errorWidget: (context, url, error) =>
+                          const Icon(Icons.error),
+                    )
+                  : FlatButton(
+                      child: const Text('Tap to download a large image'),
+                      onPressed: () =>
+                          setState(() => _downloadLargeImage = true),
+                    ),
             ),
           ],
         ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,6 +21,7 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   int currentPage = 0;
+  var _downloadLargeImage = false;
 
   @override
   Widget build(BuildContext context) {
@@ -141,6 +142,18 @@ class _MyHomePageState extends State<MyHomePage> {
                 placeholder: (context, url) => const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
               ),
+            ),
+            _sizedContainer(
+              _downloadLargeImage ?
+                CachedNetworkImage(
+                  imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/3/3f/Fronalpstock_big.jpg',
+                  placeholder: (context, url) => const CircularProgressIndicator(),
+                  errorWidget: (context, url, error) => const Icon(Icons.error),
+                ) :
+                FlatButton(
+                  child: const Text('Tap to download a large image'),
+                  onPressed: () => setState(() => _downloadLargeImage = true),
+                ),
             ),
           ],
         ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -135,6 +135,13 @@ class _MyHomePageState extends State<MyHomePage> {
                 fadeInDuration: const Duration(seconds: 3),
               ),
             ),
+            _sizedContainer(
+              CachedNetworkImage(
+                imageUrl: 'https://flutter.dev/',
+                placeholder: (context, url) => const CircularProgressIndicator(),
+                errorWidget: (context, url, error) => const Icon(Icons.error),
+              ),
+            ),
           ],
         ),
       ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,6 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_blurhash: ^0.1.2
-  bitmap: ^0.0.6
   cached_network_image:
     path: ../
 

--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -245,7 +245,8 @@ class CachedNetworkImageState extends State<CachedNetworkImage> with TickerProvi
         }
         lastHolder.animationController.reverse().then((_) {
           _imageHolders.remove(lastHolder);
-          if (mounted && lastHolder.animationController.isCompleted) setState(() {});
+          final isEmpty = _imageHolders.where((holder) => holder.image != null).isEmpty;
+          if (mounted && isEmpty) setState(() {});
           return null;
         });
       });

--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -373,22 +373,12 @@ class CachedNetworkImageState extends State<CachedNetworkImage> with TickerProvi
     ImageProvider provider,
     BuildContext context, {
     Size size,
-  }) {
-    final config = createLocalImageConfiguration(context, size: size);
+  }) async {
     final completer = Completer<void>();
-    final ImageStream stream = provider.resolve(config);
-    ImageStreamListener listener;
-    listener = ImageStreamListener(
-      (image, sync) {
-        completer.complete();
-        stream.removeListener(listener);
-      },
-      onError: (exception, stackTrace) {
-        completer.completeError(exception, stackTrace);
-        stream.removeListener(listener);
-      },
-    );
-    stream.addListener(listener);
+    await precacheImage(provider, context, size: size, onError: completer.completeError);
+    if (!completer.isCompleted) {
+      completer.complete();
+    }
     return completer.future;
   }
 

--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -125,6 +125,11 @@ class CachedNetworkImage extends StatefulWidget {
   ///  * [BlendMode], which includes an illustration of the effect of each blend mode.
   final BlendMode colorBlendMode;
 
+  /// If this is true, it will be available handling codec error.
+  ///
+  /// If this is true, placeholder is shown even while reading the image from disk.
+  final bool usePrecache;
+
   /// Target the interpolation quality for image scaling.
   ///
   /// If not given a value, defaults to FilterQuality.low.
@@ -153,6 +158,7 @@ class CachedNetworkImage extends StatefulWidget {
     this.filterQuality = FilterQuality.low,
     this.colorBlendMode,
     this.placeholderFadeInDuration,
+    this.usePrecache = true,
   })  : assert(imageUrl != null),
         assert(fadeOutDuration != null),
         assert(fadeOutCurve != null),
@@ -331,6 +337,7 @@ class CachedNetworkImageState extends State<CachedNetworkImage> with TickerProvi
   }
 
   Future _precacheImage(FileInfo fileInfo, Size size) async {
+    if (!widget.usePrecache) return;
     final completer = Completer<void>();
     await precacheImage(FileImage(fileInfo.file), context, size: size,
         onError: completer.completeError);

--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -245,7 +245,7 @@ class CachedNetworkImageState extends State<CachedNetworkImage> with TickerProvi
         }
         lastHolder.animationController.reverse().then((_) {
           _imageHolders.remove(lastHolder);
-          if (mounted) setState(() {});
+          if (mounted && lastHolder.animationController.isCompleted) setState(() {});
           return null;
         });
       });


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Error widget not shown when invalid content. #320
For example, when redirected to a not found page, but http status was 200.

### :new: What is the new behavior (if this is a feature change)?
Error widget shown when invalid content.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Open normal html url

### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter_cached_network_image/issues/320

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop