### PR TITLE
Add image cache resizing

### DIFF
--- a/example/lib/cache/sample_manager.dart
+++ b/example/lib/cache/sample_manager.dart
@@ -20,6 +20,6 @@ class SampleCacheManager extends BaseCacheManager {
   @override
   Future<String> getFilePath() async {
     var directory = await getExternalCacheDirectories();
-    return  p.join(directory[0].path, key);
+    return p.join(directory[0].path, key);
   }
 }

--- a/example/lib/cache/sample_manager.dart
+++ b/example/lib/cache/sample_manager.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+
+///
+/// This cache manager just allows us to provide a different cache directory.
+///
+class SampleCacheManager extends BaseCacheManager {
+  static const key = 'libCachedImageData';
+
+  static SampleCacheManager _instance;
+
+  factory SampleCacheManager() {
+    _instance ??= SampleCacheManager._();
+    return _instance;
+  }
+
+  SampleCacheManager._() : super(key);
+
+  @override
+  Future<String> getFilePath() async {
+    var directory = await getExternalCacheDirectories();
+    return  p.join(directory[0].path, key);
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,7 +35,8 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
-    ScaledImageCacheManager.init(cacheConfig: ScaledImageCacheConfig(storagePath: _getCacheDir()));
+    ScaledImageCacheManager.init(
+        cacheConfig: ScaledImageCacheConfig(storagePath: _getCacheDir()));
   }
 
   Future<Directory> _getCacheDir() async {
@@ -115,7 +116,8 @@ class _MyHomePageState extends State<MyHomePage> {
               CachedNetworkImage(
                 useScaleCacheManager: useScaleCache,
                 cacheManager: cacheManager,
-                placeholder: (context, url) => const CircularProgressIndicator(),
+                placeholder: (context, url) =>
+                    const CircularProgressIndicator(),
                 imageUrl: 'http://via.placeholder.com/200x150',
               ),
             ),
@@ -136,7 +138,8 @@ class _MyHomePageState extends State<MyHomePage> {
                     ),
                   ),
                 ),
-                placeholder: (context, url) => const CircularProgressIndicator(),
+                placeholder: (context, url) =>
+                    const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
               ),
             ),
@@ -158,7 +161,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 cacheManager: cacheManager,
                 useScaleCacheManager: useScaleCache,
                 imageUrl: 'http://notAvalid.uri',
-                placeholder: (context, url) => const CircularProgressIndicator(),
+                placeholder: (context, url) =>
+                    const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
               ),
             ),
@@ -167,7 +171,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 cacheManager: cacheManager,
                 useScaleCacheManager: useScaleCache,
                 imageUrl: 'not a uri at all',
-                placeholder: (context, url) => const CircularProgressIndicator(),
+                placeholder: (context, url) =>
+                    const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
               ),
             ),
@@ -176,7 +181,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 cacheManager: cacheManager,
                 useScaleCacheManager: useScaleCache,
                 imageUrl: 'http://via.placeholder.com/350x200',
-                placeholder: (context, url) => const CircularProgressIndicator(),
+                placeholder: (context, url) =>
+                    const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
                 fadeOutDuration: const Duration(seconds: 1),
                 fadeInDuration: const Duration(seconds: 3),
@@ -229,7 +235,8 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget _gridView() {
     return GridView.builder(
       itemCount: 250,
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
+      gridDelegate:
+          const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
       itemBuilder: (BuildContext context, int index) => CachedNetworkImage(
         cacheManager: cacheManager,
         useScaleCacheManager: useScaleCache,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,15 @@
+import 'dart:io';
+
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'cache/sample_manager.dart';
+
+const bool useScaleCache = true;
+
+final cacheManager = SampleCacheManager();
 
 void main() => runApp(MyApp());
 
@@ -22,6 +31,17 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   int currentPage = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    ScaledImageCacheManager.init(cacheConfig: ScaledImageCacheConfig(storagePath: _getCacheDir()));
+  }
+
+  Future<Directory> _getCacheDir() async {
+    final dirs = await getExternalCacheDirectories();
+    return dirs.first;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -72,9 +92,12 @@ class _MyHomePageState extends State<MyHomePage> {
           children: <Widget>[
             _blurHashImage(),
             _sizedContainer(
-              const Image(
+              Image(
                 image: CachedNetworkImageProvider(
                   'http://via.placeholder.com/350x150',
+                  useScaleCacheManager: useScaleCache,
+                  cacheManager: cacheManager,
+                  cacheWidth: 300,
                 ),
               ),
             ),
@@ -90,13 +113,16 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             _sizedContainer(
               CachedNetworkImage(
-                placeholder: (context, url) =>
-                    const CircularProgressIndicator(),
+                useScaleCacheManager: useScaleCache,
+                cacheManager: cacheManager,
+                placeholder: (context, url) => const CircularProgressIndicator(),
                 imageUrl: 'http://via.placeholder.com/200x150',
               ),
             ),
             _sizedContainer(
               CachedNetworkImage(
+                useScaleCacheManager: useScaleCache,
+                cacheManager: cacheManager,
                 imageUrl: 'http://via.placeholder.com/300x150',
                 imageBuilder: (context, imageProvider) => Container(
                   decoration: BoxDecoration(
@@ -110,12 +136,13 @@ class _MyHomePageState extends State<MyHomePage> {
                     ),
                   ),
                 ),
-                placeholder: (context, url) =>
-                    const CircularProgressIndicator(),
+                placeholder: (context, url) => const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
               ),
             ),
             CachedNetworkImage(
+              useScaleCacheManager: useScaleCache,
+              cacheManager: cacheManager,
               imageUrl: 'http://via.placeholder.com/300x300',
               placeholder: (context, url) => CircleAvatar(
                 backgroundColor: Colors.amber,
@@ -128,25 +155,28 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             _sizedContainer(
               CachedNetworkImage(
+                cacheManager: cacheManager,
+                useScaleCacheManager: useScaleCache,
                 imageUrl: 'http://notAvalid.uri',
-                placeholder: (context, url) =>
-                    const CircularProgressIndicator(),
+                placeholder: (context, url) => const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
               ),
             ),
             _sizedContainer(
               CachedNetworkImage(
+                cacheManager: cacheManager,
+                useScaleCacheManager: useScaleCache,
                 imageUrl: 'not a uri at all',
-                placeholder: (context, url) =>
-                    const CircularProgressIndicator(),
+                placeholder: (context, url) => const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
               ),
             ),
             _sizedContainer(
               CachedNetworkImage(
+                cacheManager: cacheManager,
+                useScaleCacheManager: useScaleCache,
                 imageUrl: 'http://via.placeholder.com/350x200',
-                placeholder: (context, url) =>
-                    const CircularProgressIndicator(),
+                placeholder: (context, url) => const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
                 fadeOutDuration: const Duration(seconds: 1),
                 fadeInDuration: const Duration(seconds: 3),
@@ -162,6 +192,8 @@ class _MyHomePageState extends State<MyHomePage> {
     return SizedBox(
       width: double.infinity,
       child: CachedNetworkImage(
+        cacheManager: cacheManager,
+        useScaleCacheManager: useScaleCache,
         placeholder: (context, url) => const AspectRatio(
           aspectRatio: 1.6,
           child: BlurHash(hash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj'),
@@ -178,6 +210,8 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Column(
           children: <Widget>[
             CachedNetworkImage(
+              cacheManager: cacheManager,
+              useScaleCacheManager: useScaleCache,
               imageUrl: 'https://loremflickr.com/320/240/music?lock=$index',
               placeholder: (BuildContext context, String url) => Container(
                 width: 320,
@@ -195,9 +229,10 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget _gridView() {
     return GridView.builder(
       itemCount: 250,
-      gridDelegate:
-          const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
       itemBuilder: (BuildContext context, int index) => CachedNetworkImage(
+        cacheManager: cacheManager,
+        useScaleCacheManager: useScaleCache,
         imageUrl: 'https://loremflickr.com/100/100/music?lock=$index',
         placeholder: _loader,
         errorWidget: _error,

--- a/lib/cached_network_image.dart
+++ b/lib/cached_network_image.dart
@@ -2,3 +2,4 @@ library cached_network_image;
 
 export 'src/cached_image_widget.dart';
 export 'src/cached_network_image_provider.dart';
+export 'src/scaled_cache_manager.dart';

--- a/lib/src/cached_network_image_provider.dart
+++ b/lib/src/cached_network_image_provider.dart
@@ -8,17 +8,20 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
 import 'scaled_cache_manager.dart';
 
-typedef void ErrorListener();
+typedef ErrorListener = void Function();
 
 class CachedNetworkImageProvider
     extends ImageProvider<CachedNetworkImageProvider> {
   /// Creates an ImageProvider which loads an image from the [url], using the [scale].
   /// When the image fails to load [errorListener] is called.
   const CachedNetworkImageProvider(this.url,
-      {this.scale = 1.0, this.errorListener, this.headers, this.cacheManager,
-        this.useScaleCacheManager,
-        this.cacheWidth,
-        this.cacheHeight})
+      {this.scale = 1.0,
+      this.errorListener,
+      this.headers,
+      this.cacheManager,
+      this.useScaleCacheManager,
+      this.cacheWidth,
+      this.cacheHeight})
       : assert(url != null),
         assert(scale != null);
 
@@ -52,7 +55,8 @@ class CachedNetworkImageProvider
   }
 
   @override
-  ImageStreamCompleter load(CachedNetworkImageProvider key, DecoderCallback decode) {
+  ImageStreamCompleter load(
+      CachedNetworkImageProvider key, DecoderCallback decode) {
     return MultiFrameImageStreamCompleter(
       codec: _loadAsync(key),
       scale: key.scale,
@@ -67,10 +71,11 @@ class CachedNetworkImageProvider
   }
 
   Future<ui.Codec> _loadAsync(CachedNetworkImageProvider key) async {
-    var mngr =
-        useScaleCacheManager ? ScaledImageCacheManager() : (cacheManager ?? DefaultCacheManager());
-    final modifiedUrl = _transformedUrl(mngr, url);
-    var file = await mngr.getSingleFile(modifiedUrl, headers: headers);
+    final manager = useScaleCacheManager
+        ? ScaledImageCacheManager()
+        : (cacheManager ?? DefaultCacheManager());
+    final modifiedUrl = _transformedUrl(manager, url);
+    var file = await manager.getSingleFile(modifiedUrl, headers: headers);
     if (file == null) {
       if (errorListener != null) errorListener();
       throw Exception('Couldn\'t download or retrieve file: $modifiedUrl');
@@ -80,7 +85,8 @@ class CachedNetworkImageProvider
 
   String _transformedUrl(BaseCacheManager manager, String url) {
     if (manager is ScaledImageCacheManager) {
-      return getDimensionSuffixedUrl(manager.cacheConfig, url, cacheWidth, cacheHeight);
+      return getDimensionSuffixedUrl(
+          manager.cacheConfig, url, cacheWidth, cacheHeight);
     } else {
       return url;
     }

--- a/lib/src/image_transformer.dart
+++ b/lib/src/image_transformer.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:path/path.dart' as p;
+
+import '../cached_network_image.dart';
+
+class DefaultImageTransformer extends ImageTransformer {
+  final ScaledImageCacheConfig config;
+
+  DefaultImageTransformer(this.config);
+
+  final tmpFileSuffix = '.tmp';
+
+  final _compressionFormats = {
+    '.jpg': CompressFormat.jpeg,
+    '.jpeg': CompressFormat.jpeg,
+    '.webp': CompressFormat.webp,
+    '.png': CompressFormat.png,
+    '.heic': CompressFormat.heic,
+  };
+  final _extensionFormats = {
+    CompressFormat.jpeg: '.jpg',
+    CompressFormat.webp: '.webp',
+    CompressFormat.png: '.png',
+    CompressFormat.heic: '.heic'
+  };
+
+  @override
+  Future<FileInfo> transform(FileInfo info, String uri) async {
+    final dimens = _getDimensionsFromUrl(uri);
+    await _scaleImageFile(info, dimens[0], dimens[1]);
+    return info;
+  }
+
+  List<int> _getDimensionsFromUrl(String url) {
+    Uri uri = Uri.parse(url);
+    String heightParam = uri.queryParameters[config.heightKey];
+    int height = heightParam != null ? int.tryParse(heightParam) : null;
+    String widthParam = uri.queryParameters[config.widthKey];
+    int width = widthParam != null ? int.tryParse(widthParam) : null;
+    return [width, height];
+  }
+
+  Future<FileInfo> _scaleImageFile(FileInfo info, int width, int height) async {
+    File file = info.file;
+    if (file.existsSync()) {
+      String extension = p.extension(file.path) ?? '';
+      final format = _compressionFormats[extension] ?? CompressFormat.png;
+      final destPath = file.path + tmpFileSuffix +_extensionFormats[format];
+      final tmpFile = File(destPath);
+      final srcSize = file.lengthSync();
+      final screen = window.physicalSize;
+      File resizedFile = await FlutterImageCompress.compressAndGetFile(file.path, tmpFile.path,
+          minWidth: width ?? screen.width.toInt(),
+          minHeight: height ?? screen.height.toInt(),
+          format: format);
+      if (resizedFile.lengthSync() < srcSize) {
+        resizedFile.renameSync(file.path);
+      } else {
+        resizedFile.deleteSync();
+      }
+    }
+    return info;
+  }
+}

--- a/lib/src/image_transformer.dart
+++ b/lib/src/image_transformer.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:path/path.dart' as p;
@@ -51,11 +50,12 @@ class DefaultImageTransformer extends ImageTransformer {
     if (file.existsSync()) {
       String extension = p.extension(file.path) ?? '';
       final format = _compressionFormats[extension] ?? CompressFormat.png;
-      final destPath = file.path + tmpFileSuffix +_extensionFormats[format];
+      final destPath = file.path + tmpFileSuffix + _extensionFormats[format];
       final tmpFile = File(destPath);
       final srcSize = file.lengthSync();
       final screen = window.physicalSize;
-      File resizedFile = await FlutterImageCompress.compressAndGetFile(file.path, tmpFile.path,
+      File resizedFile = await FlutterImageCompress.compressAndGetFile(
+          file.path, tmpFile.path,
           minWidth: width ?? screen.width.toInt(),
           minHeight: height ?? screen.height.toInt(),
           format: format);

--- a/lib/src/scaled_cache_manager.dart
+++ b/lib/src/scaled_cache_manager.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'image_transformer.dart';
+
+class ScaledImageCacheManager extends BaseCacheManager {
+  final ScaledImageCacheConfig cacheConfig;
+  final ImageTransformer transformer;
+
+  @override
+  Future<String> getFilePath() async {
+    if (cacheConfig.storagePath != null) {
+      final Directory directory = await cacheConfig.storagePath;
+      return directory.path;
+    } else {
+      final Directory directory = await getTemporaryDirectory();
+      return p.join(directory.path, key);
+    }
+  }
+
+  static const key = 'libCachedImageData';
+
+  static ScaledImageCacheManager _instance;
+
+  /// The ScaledCacheManager that can be easily used directly. The code of
+  /// this implementation can be used as inspiration for more complex cache
+  /// managers.
+  factory ScaledImageCacheManager(
+      {ScaledImageCacheConfig cacheConfig, ImageTransformer transformer}) {
+    final config = cacheConfig ?? ScaledImageCacheConfig();
+    _instance ??= ScaledImageCacheManager._(config, transformer ?? DefaultImageTransformer(config));
+    return _instance;
+  }
+
+  /// A named initializer for when clients wish to initialize the manager with custom config.
+  /// This is purely for syntax purposes.
+  factory ScaledImageCacheManager.init(
+      {ScaledImageCacheConfig cacheConfig, ImageTransformer transformer}) {
+    return ScaledImageCacheManager(cacheConfig: cacheConfig, transformer: transformer);
+  }
+
+  ScaledImageCacheManager._(this.cacheConfig, this.transformer) : super(key);
+
+  ///Download the file and add to cache
+  @override
+  Future<FileInfo> downloadFile(String url,
+      {Map<String, String> authHeaders, bool force = false}) async {
+    var response = await super.downloadFile(url, authHeaders: authHeaders, force: force);
+    response = await transformer.transform(response, url);
+    return response;
+  }
+
+  /// Get the file from the cache and/or online, depending on availability and age.
+  /// Downloaded form [url], [headers] can be used for example for authentication.
+  /// The files are returned as stream. First the cached file if available, when the
+  /// cached file is too old the newly downloaded file is returned afterwards.
+  ///
+  /// The [FileResponse] is either a [FileInfo] object for fully downloaded files
+  /// or a [DownloadProgress] object for when a file is being downloaded.
+  /// The [DownloadProgress] objects are only dispatched when [withProgress] is
+  /// set on true and the file is not available in the cache. When the file is
+  /// returned from the cache there will be no progress given, although the file
+  /// might be outdated and a new file is being downloaded in the background.
+  @override
+  Stream<FileResponse> getFileStream(String url, {Map<String, String> headers, bool withProgress}) {
+    final upStream = super.getFileStream(url, headers: headers, withProgress: withProgress);
+    final downStream = StreamController<FileResponse>();
+    upStream.listen((d) async {
+      if (d is FileInfo) {
+        d = await transformer.transform(d, url);
+      }
+      downStream.add(d);
+    });
+    return downStream.stream;
+  }
+}
+
+class ScaledImageCacheConfig {
+  ///The url param name which holds the required width value
+  final String widthKey;
+
+  ///The url param name which holds the required height value
+  final String heightKey;
+
+  /// Storage path for cache
+  final Future<Directory> storagePath;
+
+  ScaledImageCacheConfig(
+      {this.widthKey = DEFAULT_WIDTH_KEY, this.heightKey = DEFAULT_HEIGHT_KEY, this.storagePath});
+
+  static const DEFAULT_WIDTH_KEY = 'fcni_width';
+  static const DEFAULT_HEIGHT_KEY = 'fcni_height';
+}
+
+///
+/// Helper method to transform image urls
+///
+String getDimensionSuffixedUrl(ScaledImageCacheConfig config, String url, int width, int height) {
+  Uri uri;
+  try {
+    uri = Uri.parse(url);
+    if (uri != null) {
+      Map<String, String> queryParams = Map<String, String>.from(uri.queryParameters);
+      if (width != null) {
+        queryParams[config.widthKey] = width.toString();
+      }
+      if (height != null) {
+        queryParams[config.heightKey] = height.toString();
+      }
+      uri = uri.replace(queryParameters: queryParams);
+    }
+  } catch (e) {
+    print('Error occured while parsing url $e');
+  }
+  return uri?.toString() ?? url;
+}
+
+abstract class ImageTransformer {
+  Future<FileInfo> transform(FileInfo info, String uri);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^1.2.0
+  flutter_image_compress: ^0.6.5+1
 
 dev_dependencies:
   pedantic: "^1.8.0+1"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature 

### :arrow_heading_down: What is the current behavior?
Image cached on disk does not take into account the rendering box, hence more often a larger bitmap is stored and loaded into memory.

### :new: What is the new behavior (if this is a feature change)?
Images now would be downloaded and resized as per constraints. Users can set the `useScaleCacheManager` flag to try this feature gracefully instead of a breaking change.

Some known side effects are:
- For some unknown reason a couple of images aren't compressing via flutter image compress.  I would be looking into this.
- Examples have been updated for testing, would revert this once reviewers find it suitable.
- Currently, no tests have been added might work on adding these later; just looking for some dev feedback.



### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

https://github.com/Baseflow/flutter_cached_network_image/issues/286

### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop