### PR TITLE
Apply MultiImageStreamCompleter

### DIFF
--- a/lib/src/image_provider/_image_provider_io.dart
+++ b/lib/src/image_provider/_image_provider_io.dart
@@ -1,6 +1,7 @@
 import 'dart:async' show Future, StreamController;
 import 'dart:ui' as ui show Codec;
 
+import 'package:cached_network_image/src/image_provider/multi_image_stream_completer.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -54,8 +55,8 @@ class CachedNetworkImageProvider
       image_provider.CachedNetworkImageProvider key, DecoderCallback decode) {
     final StreamController<ImageChunkEvent> chunkEvents =
         StreamController<ImageChunkEvent>();
-    return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, chunkEvents, decode).first,
+    return MultiImageStreamCompleter(
+      codec: _loadAsync(key, chunkEvents, decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
       informationCollector: () sync* {

--- a/lib/src/image_provider/_image_provider_web.dart
+++ b/lib/src/image_provider/_image_provider_web.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 
+import 'package:cached_network_image/src/image_provider/multi_image_stream_completer.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -58,7 +59,7 @@ class CachedNetworkImageProvider
     final StreamController<ImageChunkEvent> chunkEvents =
         StreamController<ImageChunkEvent>();
 
-    return MultiFrameImageStreamCompleter(
+    return MultiImageStreamCompleter(
         chunkEvents: chunkEvents.stream,
         codec:
             _loadAsync(key as CachedNetworkImageProvider, chunkEvents, decode),
@@ -82,16 +83,16 @@ class CachedNetworkImageProvider
     return collector;
   }
 
-  Future<ui.Codec> _loadAsync(
+  Stream<ui.Codec> _loadAsync(
     CachedNetworkImageProvider key,
     StreamController<ImageChunkEvent> chunkEvents,
     DecoderCallback decode,
   ) {
     switch (_imageRenderMethodForWeb) {
       case ImageRenderMethodForWeb.HttpGet:
-        return _loadAsyncHttpGet(key, chunkEvents, decode).first;
+        return _loadAsyncHttpGet(key, chunkEvents, decode);
       case ImageRenderMethodForWeb.HtmlImage:
-        return loadAsyncHtmlImage(key, chunkEvents, decode);
+        return loadAsyncHtmlImage(key, chunkEvents, decode).asStream();
     }
     throw UnsupportedError(
         'ImageRenderMethod $_imageRenderMethodForWeb is not supported');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Baseflow/flutter_cached_network_image
 
 environment:
   sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.10.15-pre.148 <2.0.0"
+  flutter: ">=1.19.0-2.0.pre <2.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently only the first image is used. When the cache is updated and a newer image is provided it is ignored.

### :new: What is the new behavior (if this is a feature change)?
New behavior uses the MultiImageStreamCompleter that was already included.
This gives also the option to first load a smaller image in the future.

### :boom: Does this PR introduce a breaking change?
No, just the minimal version of Flutter had to increase to 1.18.0-8.0.pre. As OctoImage is a bit buggy in versions lower than 1.19.0-2.0.pre I set the minimal version to that. It is currently available in beta, so it should not be a very big problem.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop