### PR TITLE
Evict key from imageCache when loading fails

### DIFF
--- a/lib/src/image_provider/_image_provider_io.dart
+++ b/lib/src/image_provider/_image_provider_io.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show Future, StreamController;
+import 'dart:async' show Future, StreamController, scheduleMicrotask;
 import 'dart:ui' as ui show Codec;
 
 import 'package:cached_network_image/src/image_provider/multi_image_stream_completer.dart';
@@ -93,6 +93,13 @@ class CachedNetworkImageProvider
         }
       }
     } catch (e) {
+      // Depending on where the exception was thrown, the image cache may not
+      // have had a chance to track the key in the cache at all.
+      // Schedule a microtask to give the cache a chance to add the key.
+      scheduleMicrotask(() {
+        PaintingBinding.instance.imageCache.evict(key);
+      });
+
       errorListener?.call();
       rethrow;
     } finally {

--- a/lib/src/image_provider/_image_provider_web.dart
+++ b/lib/src/image_provider/_image_provider_web.dart
@@ -122,6 +122,13 @@ class CachedNetworkImageProvider
         }
       }
     } catch (e) {
+      // Depending on where the exception was thrown, the image cache may not
+      // have had a chance to track the key in the cache at all.
+      // Schedule a microtask to give the cache a chance to add the key.
+      scheduleMicrotask(() {
+        PaintingBinding.instance.imageCache.evict(key);
+      });
+
       errorListener?.call();
       rethrow;
     } finally {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Currently the image cache caches the result even when the result is an exception.

### :new: What is the new behavior (if this is a feature change)?
When the image fails loading evict the key from the cache allowing a reload. NetworkImage does the same.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #458
Fixes #451

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop