### PR TITLE
Added method to evict from memory and disk cache

### DIFF
--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -14,6 +14,17 @@ typedef Widget LoadingErrorWidgetBuilder(
     BuildContext context, String url, dynamic error);
 
 class CachedNetworkImage extends StatelessWidget {
+  /// Evict an image from both the disk file based caching system of the
+  /// [BaseCacheManager] as the in memory [ImageCache] of the [ImageProvider].
+  /// [url] is used by both the disk and memory cache. The scale is only used
+  /// to clear the image from the [ImageCache].
+  static Future evictFromCache(String url,
+      {BaseCacheManager cacheManager, double scale = 1.0,}) async {
+    cacheManager = cacheManager ?? DefaultCacheManager();
+    await cacheManager.removeFile(url);
+    return CachedNetworkImageProvider(url, scale: scale).evict();
+  }
+
   final CachedNetworkImageProvider _image;
 
   /// Option to use cachemanager with other settings


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
In version 2.2 it was enough to clear the file from the disk based cache and reload the image.
In version 2.3 the image also needs to be cleared from the ImageCache.

### :new: What is the new behavior (if this is a feature change)?
Adds a new helper method to clear from both the memory as the disk based cache.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
I tested it with the following code:
```
class TestHomePage extends StatefulWidget {
  @override
  _TestHomePageState createState() => _TestHomePageState();
}

class _TestHomePageState extends State<TestHomePage> {
  String url = 'http://via.placeholder.com/350x150';
  bool loading = false;
  int clearCount = 0;
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: const Text('CachedNetworkImage')),
      body: Center(
        child: loading
            ? const CircularProgressIndicator()
            : CachedNetworkImage(imageUrl: url),
      ),
      floatingActionButton: FloatingActionButton(
        onPressed: () async {
          setState(() {
            loading = true;
          });
          await CachedNetworkImage.evictFromCache(url);
          await Future.delayed(const Duration(milliseconds: 100));
          setState(() {
            loading = false;
          });
        },
        child: const Icon(Icons.refresh),
      ),
    );
  }
}
```
For some reason the image needs to be not shown on screen for a short time period for the ImageWidget to really reload the image.

### :memo: Links to relevant issues/docs
Fixes #446
Fixes #421

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop