### PR TITLE
Update basic_content.dart

### DIFF
--- a/example/lib/plugin_example/basic_content.dart
+++ b/example/lib/plugin_example/basic_content.dart
@@ -22,8 +22,10 @@ class BasicContent extends StatelessWidget {
             _sizedContainer(
               CachedNetworkImage(
                 progressIndicatorBuilder: (context, url, progress) =>
-                    CircularProgressIndicator(
+                  Center(
+                    child: CircularProgressIndicator(
                   value: progress.progress,
+                  ),
                 ),
                 imageUrl:
                     'https://images.unsplash.com/photo-1532264523420-881a47db012d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9',


### PR DESCRIPTION
When we use CircularProgressIndicator() directly, it takes up the entire card/container in which we are using CachedNetworkImage(). Hence, it doesn't look good to the user as it bloats over the container. So, it becomes better to wrap CircularProgressIndicator() inside Center() widget so it is just shown in the center of  the card/container.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Wrapped CircularProgressIndicator() into Center() widget

### :arrow_heading_down: What is the current behavior?
Currently, CircularProgressIndicator() will take up the entire size of card/container which is parent of CachedNetworkImage(). Even if CachedNetworkImage() is the parent, CircularProgressIndicator() will take up the size of Image!

### :new: What is the new behavior (if this is a feature change)?
Now, the CircularProgressIndicator() will be in Center of image/card/container and hence it will not take up all the space.

### :boom: Does this PR introduce a breaking change?
No it doesn't as it just wraps CircularProgressIndicator() into Center()

### :bug: Recommendations for testing
None

### :memo: Links to relevant issues/docs
None

### :thinking: Checklist before submitting

- [✔️] All projects build
- [✔️] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [✔️] Relevant documentation was updated
- [✔️] Rebased onto current develop