### PR TITLE
Expose DownloadProgress to prevent src imports

### DIFF
--- a/lib/cached_network_image.dart
+++ b/lib/cached_network_image.dart
@@ -1,4 +1,5 @@
 library cached_network_image;
 
+export 'package:flutter_cache_manager/src/result/download_progress.dart';
 export 'src/cached_image_widget.dart';
 export 'src/image_provider/cached_network_image_provider.dart';


### PR DESCRIPTION
### :arrow_heading_down: What is the current behavior?

Explicit import is required for `DownloadProgress`

### :new: What is the new behavior (if this is a feature change)?

`DownloadProgress` class is accessible without importing the file explicitly.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))