### PR TITLE
Custom cache key

### DIFF
--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -434,6 +435,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -456,6 +458,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,9 @@
 name: example
 description: A new Flutter project.
 
+environment:
+  sdk: ">=2.9.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -220,6 +220,7 @@ class CachedNetworkImage extends StatelessWidget {
           imageUrl,
           headers: httpHeaders,
           cacheManager: cacheManager,
+          cacheKey: cacheKey,
           imageRenderMethodForWeb: imageRenderMethodForWeb,
         ),
         super(key: key);

--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -31,6 +31,7 @@ class CachedNetworkImage extends StatelessWidget {
   /// to clear the image from the [ImageCache].
   static Future evictFromCache(
     String url, {
+    String cacheKey,
     BaseCacheManager cacheManager,
     double scale = 1.0,
   }) async {
@@ -46,6 +47,9 @@ class CachedNetworkImage extends StatelessWidget {
 
   /// The target image that is displayed.
   final String imageUrl;
+
+  /// The target image's cache key.
+  final String cacheKey;
 
   /// Optional builder to further customize the display of the image.
   final ImageWidgetBuilder imageBuilder;
@@ -201,6 +205,7 @@ class CachedNetworkImage extends StatelessWidget {
     this.placeholderFadeInDuration,
     this.memCacheWidth,
     this.memCacheHeight,
+    this.cacheKey,
     ImageRenderMethodForWeb imageRenderMethodForWeb,
   })  : assert(imageUrl != null),
         assert(fadeOutDuration != null),

--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -36,7 +36,7 @@ class CachedNetworkImage extends StatelessWidget {
     double scale = 1.0,
   }) async {
     cacheManager = cacheManager ?? DefaultCacheManager();
-    await cacheManager.removeFile(url);
+    await cacheManager.removeFile(cacheKey ?? url);
     return CachedNetworkImageProvider(url, scale: scale).evict();
   }
 

--- a/lib/src/image_provider/_image_provider_io.dart
+++ b/lib/src/image_provider/_image_provider_io.dart
@@ -114,7 +114,11 @@ class CachedNetworkImageProvider
   @override
   bool operator ==(dynamic other) {
     if (other is CachedNetworkImageProvider) {
-      return url == other.url && scale == other.scale;
+      if (cacheKey != null && other.cacheKey != null) {
+        return cacheKey == other.cacheKey && scale == other.scale;
+      } else {
+        return url == other.url && scale == other.scale;
+      }
     }
     return false;
   }

--- a/lib/src/image_provider/_image_provider_io.dart
+++ b/lib/src/image_provider/_image_provider_io.dart
@@ -82,7 +82,7 @@ class CachedNetworkImageProvider
     try {
       var mngr = cacheManager ?? DefaultCacheManager();
       await for (var result in mngr.getFileStream(key.url,
-          withProgress: true, headers: headers)) {
+          withProgress: true, headers: headers, key: key.cacheKey)) {
         if (result is DownloadProgress) {
           chunkEvents.add(ImageChunkEvent(
             cumulativeBytesLoaded: result.downloaded,

--- a/lib/src/image_provider/_image_provider_io.dart
+++ b/lib/src/image_provider/_image_provider_io.dart
@@ -114,11 +114,8 @@ class CachedNetworkImageProvider
   @override
   bool operator ==(dynamic other) {
     if (other is CachedNetworkImageProvider) {
-      if (cacheKey != null && other.cacheKey != null) {
-        return cacheKey == other.cacheKey && scale == other.scale;
-      } else {
-        return url == other.url && scale == other.scale;
-      }
+      var sameKey = (cacheKey ?? url) == (other.cacheKey ?? other.url);
+      return sameKey && scale == other.scale;
     }
     return false;
   }

--- a/lib/src/image_provider/_image_provider_io.dart
+++ b/lib/src/image_provider/_image_provider_io.dart
@@ -20,6 +20,7 @@ class CachedNetworkImageProvider
     this.errorListener,
     this.headers,
     this.cacheManager,
+    this.cacheKey,
     //ignore: avoid_unused_constructor_parameters
     ImageRenderMethodForWeb imageRenderMethodForWeb,
   })  : assert(url != null),
@@ -31,6 +32,10 @@ class CachedNetworkImageProvider
   /// Web url of the image to load
   @override
   final String url;
+
+  /// Cache key of the image to cache
+  @override
+  final String cacheKey;
 
   /// Scale of the image
   @override

--- a/lib/src/image_provider/_image_provider_web.dart
+++ b/lib/src/image_provider/_image_provider_web.dart
@@ -145,11 +145,8 @@ class CachedNetworkImageProvider
       return false;
     }
     if (other is CachedNetworkImageProvider) {
-      if (cacheKey != null && other.cacheKey != null) {
-        return cacheKey == other.cacheKey && scale == other.scale;
-      } else {
-        return url == other.url && scale == other.scale;
-      }
+      var sameKey = (cacheKey ?? url) == (other.cacheKey ?? other.url);
+      return sameKey && scale == other.scale;
     } else {
       return false;
     }

--- a/lib/src/image_provider/_image_provider_web.dart
+++ b/lib/src/image_provider/_image_provider_web.dart
@@ -144,9 +144,15 @@ class CachedNetworkImageProvider
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    return other is CachedNetworkImageProvider &&
-        other.url == url &&
-        other.scale == scale;
+    if (other is CachedNetworkImageProvider) {
+      if (cacheKey != null && other.cacheKey != null) {
+        return cacheKey == other.cacheKey && scale == other.scale;
+      } else {
+        return url == other.url && scale == other.scale;
+      }
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/lib/src/image_provider/_image_provider_web.dart
+++ b/lib/src/image_provider/_image_provider_web.dart
@@ -23,6 +23,7 @@ class CachedNetworkImageProvider
     this.errorListener,
     this.headers,
     this.cacheManager,
+    this.cacheKey,
     ImageRenderMethodForWeb imageRenderMethodForWeb,
   })  : _imageRenderMethodForWeb =
             imageRenderMethodForWeb ?? ImageRenderMethodForWeb.HtmlImage,
@@ -34,6 +35,9 @@ class CachedNetworkImageProvider
 
   @override
   final String url;
+
+  @override
+  final String cacheKey;
 
   @override
   final double scale;

--- a/lib/src/image_provider/cached_network_image_provider.dart
+++ b/lib/src/image_provider/cached_network_image_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/painting.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
 import '_image_provider_io.dart'
     if (dart.library.html) '_image_provider_web.dart' as image_provider;
 
@@ -32,6 +33,7 @@ abstract class CachedNetworkImageProvider
   /// for the benefits of each method.
   const factory CachedNetworkImageProvider(
     String url, {
+    String cacheKey,
     double scale,
     @Deprecated('ErrorListener is deprecated, use listeners on the imagestream')
         ErrorListener errorListener,
@@ -51,6 +53,9 @@ abstract class CachedNetworkImageProvider
 
   /// The URL from which the image will be fetched.
   String get url;
+
+  /// The Key from image for cache
+  String get cacheKey;
 
   /// The scale to place in the [ImageInfo] object of the image.
   double get scale;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ version: 2.3.3
 dependencies:
   flutter:
     sdk: flutter
-  flutter_cache_manager: ">=1.4.1 <3.0.0"
+  flutter_cache_manager: ">=2.0.0 <3.0.0"
   octo_image: ^0.3.0
 
 dev_dependencies:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature

### :arrow_heading_down: What is the current behavior?
The library is not support dynamic url like cloud front's secure url

### :new: What is the new behavior (if this is a feature change)?
support flutter_cache_manager 2.0.0 in Added option for a key different from the url.
Can use parameter cacheKey. if use static url, just use same.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Use CDN security url

### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter_cached_network_image/issues/488
https://github.com/Baseflow/flutter_cached_network_image/issues/428
https://github.com/Baseflow/flutter_cache_manager/pull/179

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop