### PR TITLE
Added support for resizing using ImageCacheManager

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=true

--- a/example/lib/generated_plugin_registrant.dart
+++ b/example/lib/generated_plugin_registrant.dart
@@ -1,0 +1,13 @@
+//
+// Generated file. Do not edit.
+//
+
+import 'package:url_launcher_web/url_launcher_web.dart';
+
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+// ignore: public_member_api_docs
+void registerPlugins(Registrar registrar) {
+  UrlLauncherPlugin.registerWith(registrar);
+  registrar.registerMessageHandler();
+}

--- a/example/lib/plugin_example/basic_content.dart
+++ b/example/lib/plugin_example/basic_content.dart
@@ -15,7 +15,7 @@ class BasicContent extends StatelessWidget {
             _sizedContainer(
               const Image(
                 image: CachedNetworkImageProvider(
-                  'http://via.placeholder.com/350x150',
+                  'https://via.placeholder.com/350x150',
                 ),
               ),
             ),
@@ -35,12 +35,12 @@ class BasicContent extends StatelessWidget {
               CachedNetworkImage(
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
-                imageUrl: 'http://via.placeholder.com/200x150',
+                imageUrl: 'https://via.placeholder.com/200x150',
               ),
             ),
             _sizedContainer(
               CachedNetworkImage(
-                imageUrl: 'http://via.placeholder.com/300x150',
+                imageUrl: 'https://via.placeholder.com/300x150',
                 imageBuilder: (context, imageProvider) => Container(
                   decoration: BoxDecoration(
                     image: DecorationImage(
@@ -59,7 +59,7 @@ class BasicContent extends StatelessWidget {
               ),
             ),
             CachedNetworkImage(
-              imageUrl: 'http://via.placeholder.com/300x300',
+              imageUrl: 'https://via.placeholder.com/300x300',
               placeholder: (context, url) => const CircleAvatar(
                 backgroundColor: Colors.amber,
                 radius: 150,
@@ -71,7 +71,7 @@ class BasicContent extends StatelessWidget {
             ),
             _sizedContainer(
               CachedNetworkImage(
-                imageUrl: 'http://notAvalid.uri',
+                imageUrl: 'https://notAvalid.uri',
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
@@ -87,7 +87,8 @@ class BasicContent extends StatelessWidget {
             ),
             _sizedContainer(
               CachedNetworkImage(
-                imageUrl: 'http://via.placeholder.com/350x200',
+                maxHeightDiskCache: 10,
+                imageUrl: 'https://via.placeholder.com/350x200',
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),

--- a/lib/cached_network_image.dart
+++ b/lib/cached_network_image.dart
@@ -1,5 +1,7 @@
 library cached_network_image;
 
+export 'package:flutter_cache_manager/src/result/download_progress.dart';
+
 export 'src/cached_image_widget.dart';
 export 'src/image_provider/cached_network_image_provider.dart';
 export 'src/image_provider/multi_image_stream_completer.dart';

--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -182,11 +182,17 @@ class CachedNetworkImage extends StatelessWidget {
   /// If not given a value, defaults to FilterQuality.low.
   final FilterQuality filterQuality;
 
-  /// Will resize the image in cache to have a certain width using [ResizeImage]
+  /// Will resize the image in memory to have a certain width using [ResizeImage]
   final int memCacheWidth;
 
-  /// Will resize the image in cache to have a certain height using [ResizeImage]
+  /// Will resize the image in memory to have a certain height using [ResizeImage]
   final int memCacheHeight;
+
+  /// Will resize the image and store the resized image in the disk cache.
+  final int maxWidthDiskCache;
+
+  /// Will resize the image and store the resized image in the disk cache.
+  final int maxHeightDiskCache;
 
   /// CachedNetworkImage shows a network image using a caching mechanism. It also
   /// provides support for a placeholder, showing an error and fading into the
@@ -219,6 +225,8 @@ class CachedNetworkImage extends StatelessWidget {
     this.memCacheWidth,
     this.memCacheHeight,
     this.cacheKey,
+    this.maxWidthDiskCache,
+    this.maxHeightDiskCache,
     ImageRenderMethodForWeb imageRenderMethodForWeb,
   })  : assert(imageUrl != null),
         assert(fadeOutDuration != null),
@@ -235,6 +243,8 @@ class CachedNetworkImage extends StatelessWidget {
           cacheManager: cacheManager,
           cacheKey: cacheKey,
           imageRenderMethodForWeb: imageRenderMethodForWeb,
+          maxWidth: maxWidthDiskCache,
+          maxHeight: maxHeightDiskCache,
         ),
         super(key: key);
 

--- a/lib/src/image_provider/_image_provider_web.dart
+++ b/lib/src/image_provider/_image_provider_web.dart
@@ -19,6 +19,8 @@ class CachedNetworkImageProvider
   /// The arguments [url] and [scale] must not be null.
   const CachedNetworkImageProvider(
     this.url, {
+    this.maxHeight,
+    this.maxWidth,
     this.scale = 1.0,
     this.errorListener,
     this.headers,
@@ -48,6 +50,12 @@ class CachedNetworkImageProvider
 
   @override
   final Map<String, String> headers;
+
+  @override
+  final int maxHeight;
+
+  @override
+  final int maxWidth;
 
   final ImageRenderMethodForWeb _imageRenderMethodForWeb;
 
@@ -153,7 +161,7 @@ class CachedNetworkImageProvider
   }
 
   @override
-  int get hashCode => ui.hashValues(url, scale);
+  int get hashCode => ui.hashValues(url, scale, cacheKey);
 
   @override
   String toString() => '$runtimeType("$url", scale: $scale)';

--- a/lib/src/image_provider/cached_network_image_provider.dart
+++ b/lib/src/image_provider/cached_network_image_provider.dart
@@ -40,6 +40,8 @@ abstract class CachedNetworkImageProvider
   /// for the benefits of each method.
   const factory CachedNetworkImageProvider(
     String url, {
+      int maxHeight,
+        int maxWidth,
     String cacheKey,
     double scale,
     @Deprecated('ErrorListener is deprecated, use listeners on the imagestream')
@@ -56,7 +58,6 @@ abstract class CachedNetworkImageProvider
   BaseCacheManager get cacheManager;
 
   @deprecated
-
   /// The errorListener is called when the ImageProvider failed loading the
   /// image. Deprecated in favor of [ImageStreamListener.onError].
   ErrorListener get errorListener;
@@ -72,6 +73,14 @@ abstract class CachedNetworkImageProvider
 
   /// The HTTP headers that will be used to fetch image from network.
   Map<String, String> get headers;
+
+  /// Max height in pixels for the image. When set the resized image is
+  /// stored in the cache.
+  int get maxHeight;
+
+  /// Max width in pixels for the image. When set the resized image is
+  /// stored in the cache.
+  int get maxWidth;
 
   @override
   ImageStreamCompleter load(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,4 +19,4 @@ dev_dependencies:
 
 environment:
   flutter: ">=1.20.0 <2.0.0"
-  sdk: ">=2.9.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ version: 2.4.1
 dependencies:
   flutter:
     sdk: flutter
-  flutter_cache_manager: ">=2.0.0 <3.0.0"
+  flutter_cache_manager: ^2.1.0
   octo_image: ^0.3.0
 
 dev_dependencies:

--- a/test/fake_cache_manager.dart
+++ b/test/fake_cache_manager.dart
@@ -72,6 +72,59 @@ class FakeCacheManager extends Mock implements CacheManager {
   }
 }
 
+class FakeImageCacheManager extends Mock implements ImageCacheManager {
+  ExpectedData returns(
+      String url,
+      List<int> imageData, {
+        Duration delayBetweenChunks,
+      }) {
+    const chunkSize = 8;
+    final chunks = <Uint8List>[
+      for (int offset = 0; offset < imageData.length; offset += chunkSize)
+        Uint8List.fromList(imageData.skip(offset).take(chunkSize).toList()),
+    ];
+
+    when(getImageFile(
+      url,
+      withProgress: anyNamed('withProgress'),
+      headers: anyNamed('headers'),
+      key: anyNamed('key'),
+    )).thenAnswer((realInvocation) => _createResultStream(
+      url,
+      chunks,
+      imageData,
+      delayBetweenChunks,
+    ));
+
+    return ExpectedData(
+      chunks: chunks.length,
+      totalSize: imageData.length,
+      chunkSize: chunkSize,
+    );
+  }
+
+  Stream<FileResponse> _createResultStream(
+      String url,
+      List<Uint8List> chunks,
+      List<int> imageData,
+      Duration delayBetweenChunks,
+      ) async* {
+    var totalSize = imageData.length;
+    var downloaded = 0;
+    for (var chunk in chunks) {
+      downloaded += chunk.length;
+      if (delayBetweenChunks != null) {
+        await Future.delayed(delayBetweenChunks);
+      }
+      yield DownloadProgress(url, totalSize, downloaded);
+    }
+    var file = MemoryFileSystem().systemTempDirectory.childFile('test.jpg');
+    await file.writeAsBytes(imageData);
+    yield FileInfo(
+        file, FileSource.Online, DateTime.now().add(Duration(days: 1)), url);
+  }
+}
+
 class ExpectedData {
   final int chunks;
   final int totalSize;

--- a/test/image_cache_manager_test.dart
+++ b/test/image_cache_manager_test.dart
@@ -1,0 +1,134 @@
+import 'dart:typed_data';
+
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:ui' show Codec, FrameInfo;
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_cache_manager.dart';
+import 'image_data.dart';
+import 'rendering_tester.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  TestRenderingFlutterBinding();
+
+  setUp(() {});
+
+  tearDown(() {
+    PaintingBinding.instance.imageCache.clear();
+    PaintingBinding.instance.imageCache.clearLiveImages();
+  });
+
+  test('Supplying an ImageCacheManager should call getImageFile', () async {
+    var url = 'foo.nl';
+
+    var cacheManager = FakeImageCacheManager();
+    cacheManager.returns(url, kTransparentImage);
+    final imageAvailable = Completer<void>();
+
+    final ImageProvider imageProvider =
+        CachedNetworkImageProvider(url, cacheManager: cacheManager);
+    final result = imageProvider.resolve(ImageConfiguration.empty);
+
+    result.addListener(ImageStreamListener(
+      (ImageInfo image, bool synchronousCall) {
+        imageAvailable.complete();
+      },
+    ));
+    await imageAvailable.future;
+
+    verify(cacheManager.getImageFile(
+      url,
+      withProgress: anyNamed('withProgress'),
+      headers: anyNamed('headers'),
+      key: anyNamed('key'),
+    )).called(1);
+
+    verifyNever(cacheManager.getFileStream(
+      url,
+      withProgress: anyNamed('withProgress'),
+      headers: anyNamed('headers'),
+      key: anyNamed('key'),
+    ));
+  }, skip: isBrowser);
+
+  test('Supplying an CacheManager should call getFileStream', () async {
+    var url = 'foo.nl';
+
+    var cacheManager = FakeCacheManager();
+    cacheManager.returns(url, kTransparentImage);
+    final imageAvailable = Completer<void>();
+
+    final ImageProvider imageProvider =
+        CachedNetworkImageProvider(url, cacheManager: cacheManager);
+    final result = imageProvider.resolve(ImageConfiguration.empty);
+
+    result.addListener(ImageStreamListener(
+      (ImageInfo image, bool synchronousCall) {
+        imageAvailable.complete();
+      },
+    ));
+    await imageAvailable.future;
+
+    verify(cacheManager.getFileStream(
+      url,
+      withProgress: anyNamed('withProgress'),
+      headers: anyNamed('headers'),
+      key: anyNamed('key'),
+    )).called(1);
+  }, skip: isBrowser);
+
+  test('Supplying an CacheManager with maxHeight throws assertion', () async {
+    var url = 'foo.nl';
+    final caughtError = Completer<dynamic>();
+
+    var cacheManager = FakeCacheManager();
+    cacheManager.returns(url, kTransparentImage);
+    final imageAvailable = Completer<void>();
+
+    final ImageProvider imageProvider = CachedNetworkImageProvider(url,
+        cacheManager: cacheManager, maxHeight: 20);
+    final result = imageProvider.resolve(ImageConfiguration.empty);
+
+    result.addListener(
+        ImageStreamListener((ImageInfo image, bool synchronousCall) {
+      imageAvailable.complete();
+    }, onError: (dynamic error, StackTrace stackTrace) {
+      caughtError.complete(error);
+    }));
+    final dynamic err = await caughtError.future;
+
+    expect(err, isA<AssertionError>());
+  }, skip: isBrowser);
+
+  test('Supplying an CacheManager with maxWidth throws assertion', () async {
+    var url = 'foo.nl';
+    final caughtError = Completer<dynamic>();
+
+    var cacheManager = FakeCacheManager();
+    cacheManager.returns(url, kTransparentImage);
+    final imageAvailable = Completer<void>();
+
+    final ImageProvider imageProvider = CachedNetworkImageProvider(url,
+        cacheManager: cacheManager, maxWidth: 20);
+    final result = imageProvider.resolve(ImageConfiguration.empty);
+
+    result.addListener(
+        ImageStreamListener((ImageInfo image, bool synchronousCall) {
+      imageAvailable.complete();
+    }, onError: (dynamic error, StackTrace stackTrace) {
+      caughtError.complete(error);
+    }));
+    final dynamic err = await caughtError.future;
+
+    expect(err, isA<AssertionError>());
+  }, skip: isBrowser);
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently you can only resize images in memory

### :new: What is the new behavior (if this is a feature change)?
Uses the new resize functionality of the CacheManager to store the resized images.

### :boom: Does this PR introduce a breaking change?
No, it just adds new properties.

### :bug: Recommendations for testing
You can test with setting maxWidthDiskCache very small, you will get a small image.

### :memo: Links to relevant issues/docs
Can help with #429

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop