### PR TITLE
add flag to automatically set cache dimensions

### DIFF
--- a/example/lib/plugin_example/list_content.dart
+++ b/example/lib/plugin_example/list_content.dart
@@ -16,6 +16,7 @@ class ListContent extends StatelessWidget {
                 height: 240,
                 color: Colors.purple,
               ),
+              autoDetectCacheSize: true,
             ),
           ],
         ),

--- a/lib/src/cached_image_widget.dart
+++ b/lib/src/cached_image_widget.dart
@@ -188,6 +188,10 @@ class CachedNetworkImage extends StatelessWidget {
   /// Will resize the image in memory to have a certain height using [ResizeImage]
   final int memCacheHeight;
 
+  /// Will auto detect size and cache accordingly. Enabling this makes
+  /// [memCacheWidth], [memCacheHeight] flags redundant.
+  final bool autoDetectCacheSize;
+
   /// Will resize the image and store the resized image in the disk cache.
   final int maxWidthDiskCache;
 
@@ -227,6 +231,7 @@ class CachedNetworkImage extends StatelessWidget {
     this.cacheKey,
     this.maxWidthDiskCache,
     this.maxHeightDiskCache,
+    this.autoDetectCacheSize = false,
     ImageRenderMethodForWeb imageRenderMethodForWeb,
   })  : assert(imageUrl != null),
         assert(fadeOutDuration != null),
@@ -263,30 +268,44 @@ class CachedNetworkImage extends StatelessWidget {
       octoPlaceholderBuilder = (context) => Container();
     }
 
-    return OctoImage(
-      image: _image,
-      imageBuilder: imageBuilder != null ? _octoImageBuilder : null,
-      placeholderBuilder: octoPlaceholderBuilder,
-      progressIndicatorBuilder: octoProgressIndicatorBuilder,
-      errorBuilder: errorWidget != null ? _octoErrorBuilder : null,
-      fadeOutDuration: fadeOutDuration,
-      fadeOutCurve: fadeOutCurve,
-      fadeInDuration: fadeInDuration,
-      fadeInCurve: fadeInCurve,
-      width: width,
-      height: height,
-      fit: fit,
-      alignment: alignment,
-      repeat: repeat,
-      matchTextDirection: matchTextDirection,
-      color: color,
-      filterQuality: filterQuality,
-      colorBlendMode: colorBlendMode,
-      placeholderFadeInDuration: placeholderFadeInDuration,
-      gaplessPlayback: useOldImageOnUrlChange,
-      memCacheWidth: memCacheWidth,
-      memCacheHeight: memCacheHeight,
-    );
+    return LayoutBuilder(builder: (ctx, constraints) {
+      var _constrainWidth = memCacheWidth;
+      var _constrainHeight = memCacheHeight;
+
+      if (autoDetectCacheSize) {
+        final ratio = MediaQuery.of(context).devicePixelRatio;
+        _constrainWidth = constraints.maxWidth != double.infinity
+            ? (constraints.maxWidth * ratio).toInt()
+            : null;
+        _constrainHeight = constraints.maxHeight != double.infinity
+            ? (constraints.maxHeight * ratio).toInt()
+            : null;
+      }
+      return OctoImage(
+        image: _image,
+        imageBuilder: imageBuilder != null ? _octoImageBuilder : null,
+        placeholderBuilder: octoPlaceholderBuilder,
+        progressIndicatorBuilder: octoProgressIndicatorBuilder,
+        errorBuilder: errorWidget != null ? _octoErrorBuilder : null,
+        fadeOutDuration: fadeOutDuration,
+        fadeOutCurve: fadeOutCurve,
+        fadeInDuration: fadeInDuration,
+        fadeInCurve: fadeInCurve,
+        width: width,
+        height: height,
+        fit: fit,
+        alignment: alignment,
+        repeat: repeat,
+        matchTextDirection: matchTextDirection,
+        color: color,
+        filterQuality: filterQuality,
+        colorBlendMode: colorBlendMode,
+        placeholderFadeInDuration: placeholderFadeInDuration,
+        gaplessPlayback: useOldImageOnUrlChange,
+        memCacheWidth: _constrainWidth,
+        memCacheHeight: _constrainHeight,
+      );
+    });
   }
 
   Widget _octoImageBuilder(BuildContext context, Widget child) {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
- Wraps Octo into a `LayoutBuilder` which allows a convenient way to auto-detect layout bounds and set the memcache dimensions accordingly via a flag `autoDetectCacheSize`

### :arrow_heading_down: What is the current behavior?
User needs to supply cache dimensions via `memCacheWidth` and `memCacheHeight`.

### :new: What is the new behavior (if this is a feature change)?
adds a new flag that autodetect the layout dimensions.

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
- Also would be helpful if we can extend this to the disk cache parameters; however, that would involve making the ImageProvider non-final.


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop