### PR TITLE
Expose `scale` of CachedNetworkImageProvider on CachedNetworkImage

### DIFF
--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -240,6 +240,7 @@ class CachedNetworkImage extends StatelessWidget {
     this.errorListener,
     ImageRenderMethodForWeb imageRenderMethodForWeb =
         ImageRenderMethodForWeb.HtmlImage,
+    double scale = 1.0,
   }) : _image = CachedNetworkImageProvider(
           imageUrl,
           headers: httpHeaders,
@@ -249,6 +250,7 @@ class CachedNetworkImage extends StatelessWidget {
           maxWidth: maxWidthDiskCache,
           maxHeight: maxHeightDiskCache,
           errorListener: errorListener,
+          scale: scale,
         );
 
   @override


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This PR exposes the `scale` argument of `CachedNetworkImageProvider` in the `CachedNetworkImage` constructor.

### :arrow_heading_down: What is the current behavior?

Currently you cannot set the `scale` used by the implicitly instantiated `CachedNetworkImageProvider`, so if you need to set the image scale then you have to use something like `Image(image: CachedNetworkImageProvider(url))` so you can't take advantage of the various nice features of `CachedNetworkImage`.

### :new: What is the new behavior (if this is a feature change)?

Now you can pass the `scale` argument.

### :boom: Does this PR introduce a breaking change?

No. The argument has the same default as `CachedNetworkImageProvider` so the behavior is unchanged if not supplied.

### :bug: Recommendations for testing

Try supplying different values of `scale` to `CachedNetworkImage` and ensure they take effect.

### :memo: Links to relevant issues/docs

#572

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop