### PR TITLE
fix evict key error when use memCache

### DIFF
--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -6,6 +6,8 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:octo_image/octo_image.dart';
 
+import 'image_provider/cached_resize_image.dart';
+
 /// Builder function to create an image widget. The function is called after
 /// the ImageProvider completes the image loading.
 typedef ImageWidgetBuilder = Widget Function(
@@ -230,15 +232,15 @@ class CachedNetworkImage extends StatelessWidget {
     this.maxHeightDiskCache,
     ImageRenderMethodForWeb imageRenderMethodForWeb =
         ImageRenderMethodForWeb.HtmlImage,
-  })  : _image = CachedNetworkImageProvider(
-          imageUrl,
-          headers: httpHeaders,
-          cacheManager: cacheManager,
-          cacheKey: cacheKey,
-          imageRenderMethodForWeb: imageRenderMethodForWeb,
-          maxWidth: maxWidthDiskCache,
-          maxHeight: maxHeightDiskCache,
-        ),
+  })  : _image = CachedNetworkImageProvider(imageUrl,
+            headers: httpHeaders,
+            cacheManager: cacheManager,
+            cacheKey: cacheKey,
+            imageRenderMethodForWeb: imageRenderMethodForWeb,
+            maxWidth: maxWidthDiskCache,
+            maxHeight: maxHeightDiskCache,
+            memCacheHeight: memCacheHeight,
+            memCacheWidth: memCacheWidth),
         super(key: key);
 
   @override
@@ -257,7 +259,8 @@ class CachedNetworkImage extends StatelessWidget {
     }
 
     return OctoImage(
-      image: _image,
+      image: CachedResizeImage.resizeIfNeeded(
+          memCacheWidth, memCacheHeight, _image),
       imageBuilder: imageBuilder != null ? _octoImageBuilder : null,
       placeholderBuilder: octoPlaceholderBuilder,
       progressIndicatorBuilder: octoProgressIndicatorBuilder,
@@ -277,8 +280,6 @@ class CachedNetworkImage extends StatelessWidget {
       colorBlendMode: colorBlendMode,
       placeholderFadeInDuration: placeholderFadeInDuration,
       gaplessPlayback: useOldImageOnUrlChange,
-      memCacheWidth: memCacheWidth,
-      memCacheHeight: memCacheHeight,
     );
   }
 

--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -3,17 +3,17 @@ import 'dart:ui' as ui show Codec;
 
 import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
     show ImageRenderMethodForWeb;
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
+    if (dart.library.io) '_image_loader.dart'
+    if (dart.library.html) 'package:cached_network_image_web/cached_network_image_web.dart'
+    show ImageLoader;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
 import 'cached_network_image_provider.dart' as image_provider;
+import 'cached_resize_image.dart';
 import 'multi_image_stream_completer.dart';
-
-import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
-    if (dart.library.io) '_image_loader.dart'
-    if (dart.library.html) 'package:cached_network_image_web/cached_network_image_web.dart'
-    show ImageLoader;
 
 /// Function which is called after loading the image failed.
 typedef ErrorListener = void Function();
@@ -32,9 +32,17 @@ class CachedNetworkImageProvider
     this.errorListener,
     this.headers,
     this.cacheManager,
+    this.memCacheHeight,
+    this.memCacheWidth,
     this.cacheKey,
     this.imageRenderMethodForWeb = ImageRenderMethodForWeb.HtmlImage,
   });
+
+  /// Will resize the image in memory to have a certain width using [ResizeImage]
+  final int? memCacheWidth;
+
+  /// Will resize the image in memory to have a certain height using [ResizeImage]
+  final int? memCacheHeight;
 
   /// CacheManager from which the image files are loaded.
   final BaseCacheManager? cacheManager;
@@ -95,6 +103,10 @@ class CachedNetworkImageProvider
     DecoderCallback decode,
   ) {
     assert(key == this);
+    Object evictKey = key;
+    if (memCacheHeight != null || memCacheWidth != null) {
+      evictKey = CachedResizeImageKey(key, memCacheWidth, memCacheHeight);
+    }
     return ImageLoader().loadAsync(
       url,
       cacheKey,
@@ -106,7 +118,7 @@ class CachedNetworkImageProvider
       headers,
       errorListener,
       imageRenderMethodForWeb,
-      () => PaintingBinding.instance?.imageCache?.evict(key),
+      () => PaintingBinding.instance?.imageCache?.evict(evictKey),
     );
   }
 

--- a/cached_network_image/lib/src/image_provider/cached_resize_image.dart
+++ b/cached_network_image/lib/src/image_provider/cached_resize_image.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui show Codec;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// Key used internally by [CachedResizeImage].
+///
+/// This is used to identify the precise resource in the [imageCache].
+class CachedResizeImageKey {
+  // Private constructor so nobody from the outside can poison the image cache
+  // with this key. It's only accessible to [CachedResizeImage] internally.
+  const CachedResizeImageKey(this._providerCacheKey, this._width, this._height);
+
+  final Object _providerCacheKey;
+  final int? _width;
+  final int? _height;
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) return false;
+    return other is CachedResizeImageKey &&
+        other._providerCacheKey == _providerCacheKey &&
+        other._width == _width &&
+        other._height == _height;
+  }
+
+  @override
+  int get hashCode => hashValues(_providerCacheKey, _width, _height);
+}
+
+/// Instructs Flutter to decode the image at the specified dimensions
+/// instead of at its native size.
+///
+/// This allows finer control of the size of the image in [ImageCache] and is
+/// generally used to reduce the memory footprint of [ImageCache].
+///
+/// The decoded image may still be displayed at sizes other than the
+/// cached size provided here.
+class CachedResizeImage extends ImageProvider<CachedResizeImageKey> {
+  /// Creates an ImageProvider that decodes the image to the specified size.
+  ///
+  /// The cached image will be directly decoded and stored at the resolution
+  /// defined by `width` and `height`. The image will lose detail and
+  /// use less memory if resized to a size smaller than the native size.
+  const CachedResizeImage(
+    this.imageProvider, {
+    this.width,
+    this.height,
+    this.allowUpscaling = false,
+  })  : assert(width != null || height != null),
+        assert(allowUpscaling != null);
+
+  /// The [ImageProvider] that this class wraps.
+  final ImageProvider imageProvider;
+
+  /// The width the image should decode to and cache.
+  final int? width;
+
+  /// The height the image should decode to and cache.
+  final int? height;
+
+  /// Whether the [width] and [height] parameters should be clamped to the
+  /// intrinsic width and height of the image.
+  ///
+  /// In general, it is better for memory usage to avoid scaling the image
+  /// beyond its intrinsic dimensions when decoding it. If there is a need to
+  /// scale an image larger, it is better to apply a scale to the canvas, or
+  /// to use an appropriate [Image.fit].
+  final bool allowUpscaling;
+
+  /// Composes the `provider` in a [CachedResizeImage] only when `cacheWidth` and
+  /// `cacheHeight` are not both null.
+  ///
+  /// When `cacheWidth` and `cacheHeight` are both null, this will return the
+  /// `provider` directly.
+  static ImageProvider<Object> resizeIfNeeded(
+      int? cacheWidth, int? cacheHeight, ImageProvider<Object> provider) {
+    if (cacheWidth != null || cacheHeight != null) {
+      return CachedResizeImage(provider,
+          width: cacheWidth, height: cacheHeight);
+    }
+    return provider;
+  }
+
+  @override
+  ImageStreamCompleter load(CachedResizeImageKey key, DecoderCallback decode) {
+    Future<ui.Codec> decodeResize(Uint8List bytes,
+        {int? cacheWidth, int? cacheHeight, bool? allowUpscaling}) {
+      assert(
+        cacheWidth == null && cacheHeight == null && allowUpscaling == null,
+        'CachedResizeImage cannot be composed with another ImageProvider that applies '
+        'cacheWidth, cacheHeight, or allowUpscaling.',
+      );
+      return decode(bytes,
+          cacheWidth: width,
+          cacheHeight: height,
+          allowUpscaling: this.allowUpscaling);
+    }
+
+    final ImageStreamCompleter completer =
+        imageProvider.load(key._providerCacheKey, decodeResize);
+    if (!kReleaseMode) {
+      completer.debugLabel =
+          '${completer.debugLabel} - Resized(${key._width}×${key._height})';
+    }
+    return completer;
+  }
+
+  @override
+  Future<CachedResizeImageKey> obtainKey(ImageConfiguration configuration) {
+    Completer<CachedResizeImageKey>? completer;
+    // If the imageProvider.obtainKey future is synchronous, then we will be able to fill in result with
+    // a value before completer is initialized below.
+    SynchronousFuture<CachedResizeImageKey>? result;
+    imageProvider.obtainKey(configuration).then((Object key) {
+      if (completer == null) {
+        // This future has completed synchronously (completer was never assigned),
+        // so we can directly create the synchronous result to return.
+        result = SynchronousFuture<CachedResizeImageKey>(
+            CachedResizeImageKey(key, width, height));
+      } else {
+        // This future did not synchronously complete.
+        completer.complete(CachedResizeImageKey(key, width, height));
+      }
+    });
+    if (result != null) {
+      return result!;
+    }
+    // If the code reaches here, it means the imageProvider.obtainKey was not
+    // completed sync, so we initialize the completer for completion later.
+    completer = Completer<CachedResizeImageKey>();
+    return completer.future;
+  }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
if use memCacheHeight/memCacheWidth in CachedNetworkImage, it's cause the error image cannot reload again when load failed at first time. Because the flutter ResizeImage has bug.

### :arrow_heading_down: What is the current behavior?
Now, if load failed at first time, it can reload again at next time in new CachedNetworkImage widget

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing
Use memCacheHeight/memCacheWidth in CachedNetworkImage in a page, close network, pop page, open network, push page, look if the image reload

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop