### PR TITLE
Add log option

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.2.0] - 2021-11-29
+* Add option to set the log level of the cache manager, for example:
+```dart
+CachedNetworkImage.logLevel = CacheManagerLogLevel.debug;
+```
+* Update cache manager dependency.
+
 ## [3.1.0+1] - 2021-11-04
 * Update Readme
 

--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -5,6 +5,8 @@ import 'package:baseflow_plugin_template/baseflow_plugin_template.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';
 
 void main() {
+  CachedNetworkImage.logLevel = CacheManagerLogLevel.debug;
+
   runApp(BaseflowPluginExample(
     pluginName: 'CachedNetworkImage',
     githubURL: 'https://github.com/Baseflow/flutter_cache_manager',

--- a/cached_network_image/lib/cached_network_image.dart
+++ b/cached_network_image/lib/cached_network_image.dart
@@ -1,6 +1,7 @@
 library cached_network_image;
 
-export 'package:flutter_cache_manager/src/result/download_progress.dart';
+export 'package:flutter_cache_manager/flutter_cache_manager.dart'
+    show CacheManagerLogLevel, DownloadProgress;
 export 'src/cached_image_widget.dart';
 export 'src/image_provider/cached_network_image_provider.dart';
 export 'src/image_provider/multi_image_stream_completer.dart';

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -39,6 +39,13 @@ typedef LoadingErrorWidgetBuilder = Widget Function(
 
 /// Image widget to show NetworkImage with caching functionality.
 class CachedNetworkImage extends StatelessWidget {
+  /// Get the current log level of the cache manager.
+  static CacheManagerLogLevel get logLevel => CacheManager.logLevel;
+
+  /// Set the log level of the cache manager to a [CacheManagerLogLevel].
+  static set logLevel(CacheManagerLogLevel level) =>
+      CacheManager.logLevel = level;
+
   /// Evict an image from both the disk file based caching system of the
   /// [BaseCacheManager] as the in memory [ImageCache] of the [ImageProvider].
   /// [url] is used by both the disk and memory cache. The scale is only used

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -2,12 +2,12 @@ name: cached_network_image
 description: Flutter library to load and cache network images.
   Can also be used with placeholder and error widgets.
 homepage: https://github.com/Baseflow/flutter_cached_network_image
-version: 3.1.0+1
+version: 3.2.0
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_cache_manager: ^3.0.0
+  flutter_cache_manager: ^3.3.0
   octo_image: ^1.0.0
   cached_network_image_platform_interface: ^1.0.0
   cached_network_image_web: ^1.0.0

--- a/cached_network_image/test/image_widget_test.dart
+++ b/cached_network_image/test/image_widget_test.dart
@@ -17,6 +17,22 @@ void main() {
     PaintingBinding.instance?.imageCache?.clearLiveImages();
   });
 
+  group('test logger', () {
+    test('set log level', () {
+      CachedNetworkImage.logLevel = CacheManagerLogLevel.verbose;
+      expect(CachedNetworkImage.logLevel, CacheManagerLogLevel.verbose);
+
+      CachedNetworkImage.logLevel = CacheManagerLogLevel.debug;
+      expect(CachedNetworkImage.logLevel, CacheManagerLogLevel.debug);
+
+      CachedNetworkImage.logLevel = CacheManagerLogLevel.warning;
+      expect(CachedNetworkImage.logLevel, CacheManagerLogLevel.warning);
+
+      CachedNetworkImage.logLevel = CacheManagerLogLevel.none;
+      expect(CachedNetworkImage.logLevel, CacheManagerLogLevel.none);
+    });
+  });
+
   group('widget tests', () {
     testWidgets('progress indicator called when success', (tester) async {
       var imageUrl = '123';


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently there is no way to set the log level of the cache manager

### :new: What is the new behavior (if this is a feature change)?
Gives an option to set the log level, uses the option from https://github.com/Baseflow/flutter_cache_manager/pull/350

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #351

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop