### PR TITLE
Fix Flutter 3.0 warnings

### DIFF
--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -106,7 +106,7 @@ class CachedNetworkImageProvider
       headers,
       errorListener,
       imageRenderMethodForWeb,
-      () => PaintingBinding.instance?.imageCache?.evict(key),
+      () => PaintingBinding.instance.imageCache?.evict(key),
     );
   }
 

--- a/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
+++ b/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
@@ -149,7 +149,7 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
       return;
     }
     _frameCallbackScheduled = true;
-    SchedulerBinding.instance?.scheduleFrameCallback(_handleAppFrame);
+    SchedulerBinding.instance.scheduleFrameCallback(_handleAppFrame);
   }
 
   void _emitFrame(ImageInfo imageInfo) {

--- a/cached_network_image/test/image_cache_manager_test.dart
+++ b/cached_network_image/test/image_cache_manager_test.dart
@@ -15,8 +15,8 @@ void main() {
   setUp(() {});
 
   tearDown(() {
-    PaintingBinding.instance?.imageCache?.clear();
-    PaintingBinding.instance?.imageCache?.clearLiveImages();
+    PaintingBinding.instance.imageCache?.clear();
+    PaintingBinding.instance.imageCache?.clearLiveImages();
   });
 
   test('Supplying an ImageCacheManager should call getImageFile', () async {

--- a/cached_network_image/test/image_provider_test.dart
+++ b/cached_network_image/test/image_provider_test.dart
@@ -26,8 +26,8 @@ void main() {
   });
 
   tearDown(() {
-    PaintingBinding.instance?.imageCache?.clear();
-    PaintingBinding.instance?.imageCache?.clearLiveImages();
+    PaintingBinding.instance.imageCache?.clear();
+    PaintingBinding.instance.imageCache?.clearLiveImages();
   });
 
   test('Expect thrown exception with statusCode - evicts from cache', () async {

--- a/cached_network_image/test/image_widget_test.dart
+++ b/cached_network_image/test/image_widget_test.dart
@@ -13,8 +13,8 @@ void main() {
   });
 
   tearDown(() {
-    PaintingBinding.instance?.imageCache?.clear();
-    PaintingBinding.instance?.imageCache?.clearLiveImages();
+    PaintingBinding.instance.imageCache?.clear();
+    PaintingBinding.instance.imageCache?.clearLiveImages();
   });
 
   group('test logger', () {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix flutter 3.0 warnings

### :arrow_heading_down: What is the current behavior?
Having multiple warnings each time we build an application using the `CachedNetworkImage`

### :new: What is the new behavior (if this is a feature change)?
Nothing
