### PR TITLE
Remove ? operators for compatibility with flutter 3

### DIFF
--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -106,7 +106,7 @@ class CachedNetworkImageProvider
       headers,
       errorListener,
       imageRenderMethodForWeb,
-      () => PaintingBinding.instance?.imageCache?.evict(key),
+      () => PaintingBinding.instance.imageCache.evict(key),
     );
   }
 

--- a/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
+++ b/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
@@ -149,7 +149,7 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
       return;
     }
     _frameCallbackScheduled = true;
-    SchedulerBinding.instance?.scheduleFrameCallback(_handleAppFrame);
+    SchedulerBinding.instance.scheduleFrameCallback(_handleAppFrame);
   }
 
   void _emitFrame(ImageInfo imageInfo) {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix with Flutter 3

### :arrow_heading_down: What is the current behavior?
Uses nullable operator with PaintingBinding and SchedulerBinding. It works with Flutter 2 but breaks Flutter 3

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
Yes. It should break Flutter 2 (I didn't test it)

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter_cached_network_image/issues/721

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [X] Rebased onto current develop