### PR TITLE
Update cached_network_image_provider.dart

### DIFF
--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -106,7 +106,7 @@ class CachedNetworkImageProvider
       headers,
       errorListener,
       imageRenderMethodForWeb,
-      () => PaintingBinding.instance?.imageCache?.evict(key),
+      () => PaintingBinding.instance.imageCache.evict(key),
     );
   }
 


### PR DESCRIPTION
Fixed (2/2) the null operand warning after upgrading to flutter 3.0.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes warning during compilation after flutter 3.0 upgrade

### :arrow_heading_down: What is the current behavior?
A warning is displayed during compiling for ios and android.

### :new: What is the new behavior (if this is a feature change)?
warning is gone, no feature changes.

### :boom: Does this PR introduce a breaking change?
no :)

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop