### PR TITLE
Package updates / chores for suppressing a warning and fixing for a typo

### DIFF
--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:baseflow_plugin_template/baseflow_plugin_template.dart';
+// ignore: depend_on_referenced_packages
 import 'package:flutter_blurhash/flutter_blurhash.dart';
 
 void main() {

--- a/cached_network_image/example/pubspec.yaml
+++ b/cached_network_image/example/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
 
 # For information on the generic Dart part of this file, see the

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -254,7 +254,7 @@ class CachedNetworkImage extends StatelessWidget {
     var octoProgressIndicatorBuilder =
         progressIndicatorBuilder != null ? _octoProgressIndicatorBuilder : null;
 
-    ///If there is no placeholer OctoImage does not fade, so always set an
+    ///If there is no placeholder OctoImage does not fade, so always set an
     ///(empty) placeholder as this always used to be the behaviour of
     ///CachedNetworkImage.
     if (octoPlaceholderBuilder == null &&

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^3.3.0
-  octo_image: ^1.0.2
+  octo_image: ^1.0.1
   cached_network_image_platform_interface: ^1.0.0
   cached_network_image_web: ^1.0.0
 

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^3.3.0
-  octo_image: ^1.0.0
+  octo_image: ^1.0.2
   cached_network_image_platform_interface: ^1.0.0
   cached_network_image_web: ^1.0.0
 
@@ -16,8 +16,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mocktail: ^0.1.1
-  flutter_lints: ^1.0.4
+  mocktail: ^0.3.0
+  flutter_lints: ^2.0.1
   file: ^6.1.0
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Just chores which seem missed with the 3.2.1 release

### :arrow_heading_down: What is the current behavior?
no behavior change by the commits in this PR

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
v3.2.1 bumped Flutter version to v3. However, packages like flutter_lints were not updated. So this PR addresses that. Also, chores for suppressing a lint warning and fixing a typo are included.

### :thinking: Checklist before submitting
N/A for not checked on

- [x ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ x] Rebased onto current develop