### PR TITLE
Update links for pub.dev

### DIFF
--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -1,7 +1,8 @@
 name: cached_network_image
 description: Flutter library to load and cache network images.
   Can also be used with placeholder and error widgets.
-homepage: https://github.com/Baseflow/flutter_cached_network_image
+repository: https://github.com/Baseflow/flutter_cached_network_image
+issue_tracker: https://github.com/Baseflow/flutter_cached_network_image/issues
 version: 3.2.2
 
 dependencies:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).


### :arrow_heading_down: What is the current behavior?

It shows a `Homepage` link


### :new: What is the new behavior (if this is a feature change)?

It shows links to `Repository (GitHub)` and `View/report issues`


### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop