### PR TITLE
Fix #785 Cancel chunk events stream subscription when imageStream is disposed

### DIFF
--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -77,7 +77,7 @@ class CachedNetworkImageProvider
   ImageStreamCompleter load(
       image_provider.CachedNetworkImageProvider key, DecoderCallback decode) {
     final chunkEvents = StreamController<ImageChunkEvent>();
-    final imageStreamCompleter = MultiImageStreamCompleter(
+    return MultiImageStreamCompleter(
       codec: _loadAsync(key, chunkEvents, decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
@@ -89,10 +89,6 @@ class CachedNetworkImageProvider
         );
       },
     );
-
-    _handleChunkEventsClose(imageStreamCompleter, chunkEvents);
-
-    return imageStreamCompleter;
   }
 
   @Deprecated(
@@ -122,7 +118,7 @@ class CachedNetworkImageProvider
   ImageStreamCompleter loadBuffer(image_provider.CachedNetworkImageProvider key,
       DecoderBufferCallback decode) {
     final chunkEvents = StreamController<ImageChunkEvent>();
-    final imageStreamCompleter = MultiImageStreamCompleter(
+    return MultiImageStreamCompleter(
       codec: _loadBufferAsync(key, chunkEvents, decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
@@ -134,10 +130,6 @@ class CachedNetworkImageProvider
         );
       },
     );
-
-    _handleChunkEventsClose(imageStreamCompleter, chunkEvents);
-
-    return imageStreamCompleter;
   }
 
   Stream<ui.Codec> _loadBufferAsync(
@@ -170,21 +162,6 @@ class CachedNetworkImageProvider
           maxWidth == other.maxWidth;
     }
     return false;
-  }
-
-  void _handleChunkEventsClose(
-    ImageStreamCompleter imageStreamCompleter,
-    StreamController<ImageChunkEvent> chunkEvents,
-  ) {
-    // Make sure to close the chunk events controller after
-    // the image stream disposes. Otherwise reporting an image chunk
-    // event could fail beacause the ImageStream has been disposed.
-    // (https://github.com/Baseflow/flutter_cached_network_image/issues/785)
-    imageStreamCompleter.addOnLastListenerRemovedCallback(() {
-      if (!chunkEvents.isClosed) {
-        chunkEvents.close();
-      }
-    });
   }
 
   @override

--- a/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
+++ b/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
@@ -70,7 +70,7 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
   // Used to guard against registering multiple _handleAppFrame callbacks for the same frame.
   bool _frameCallbackScheduled = false;
 
-  /// We must avoid disposing a completer if it has never had a listener, even
+  /// We must avoid disposing a completer if it never had a listener, even
   /// if all [keepAlive] handles get disposed.
   bool __hadAtLeastOneListener = false;
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix


### :arrow_heading_down: What is the current behavior?

#785 There seems to be a situation where a new chunkEvent is being reported and the Image Stream has already been disposed.


### :new: What is the new behavior (if this is a feature change)?

It makes sure to remove the chunk events Stream subscription once the ImageStream is disposed. Since the completer base class does not expose the properties that indicate when it has been disposed, we need to replicate some of the logic.

~~This adds a listener for when the last ImageStream is removed. This is when the ImageStream is disposed, so we have a chance to close the chunkEvents `StreamController`.~~
I wasn't able to reproduce the original issue on my device, but I'm seeing thousands of "silent" error reports from the `checkDisposed` assert in user stacktraces.
Fortunately, the test case added provides a way to reproduce the issue.


### :boom: Does this PR introduce a breaking change?

No


### :bug: Recommendations for testing

A test case has been included

### :memo: Links to relevant issues/docs

#785 


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop