### PR TITLE
Replace error type from dynamic to Object

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.2.4] - 
+* Replace error type in `LoadingErrorWidgetBuilder` from dynamic to Object
+
 ## [3.2.3] - 2022-11-25
 * Correctly dispose image stream handler
 

--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -1,6 +1,6 @@
+import 'package:baseflow_plugin_template/baseflow_plugin_template.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:baseflow_plugin_template/baseflow_plugin_template.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';
 
 void main() {
@@ -199,12 +199,10 @@ class GridContent extends StatelessWidget {
   }
 
   Widget _loader(BuildContext context, String url) {
-    return const Center(
-      child: CircularProgressIndicator(),
-    );
+    return const Center(child: CircularProgressIndicator());
   }
 
-  Widget _error(BuildContext context, String url, dynamic error) {
+  Widget _error(BuildContext context, String url, Object error) {
     return const Center(child: Icon(Icons.error));
   }
 }

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -33,7 +33,7 @@ typedef ProgressIndicatorBuilder = Widget Function(
 typedef LoadingErrorWidgetBuilder = Widget Function(
   BuildContext context,
   String url,
-  dynamic error,
+  Object error,
 );
 
 /// Image widget to show NetworkImage with caching functionality.
@@ -49,13 +49,13 @@ class CachedNetworkImage extends StatelessWidget {
   /// [BaseCacheManager] as the in memory [ImageCache] of the [ImageProvider].
   /// [url] is used by both the disk and memory cache. The scale is only used
   /// to clear the image from the [ImageCache].
-  static Future evictFromCache(
+  static Future<bool> evictFromCache(
     String url, {
     String? cacheKey,
-    BaseCacheManager? cacheManager,
+    BaseCacheManager? baseCacheManager,
     double scale = 1.0,
   }) async {
-    cacheManager = cacheManager ?? DefaultCacheManager();
+    final cacheManager = baseCacheManager ?? DefaultCacheManager();
     await cacheManager.removeFile(cacheKey ?? url);
     return CachedNetworkImageProvider(url, scale: scale).evict();
   }
@@ -254,7 +254,7 @@ class CachedNetworkImage extends StatelessWidget {
     var octoProgressIndicatorBuilder =
         progressIndicatorBuilder != null ? _octoProgressIndicatorBuilder : null;
 
-    ///If there is no placeholer OctoImage does not fade, so always set an
+    ///If there is no placeholder OctoImage does not fade, so always set an
     ///(empty) placeholder as this always used to be the behaviour of
     ///CachedNetworkImage.
     if (octoPlaceholderBuilder == null &&
@@ -307,7 +307,10 @@ class CachedNetworkImage extends StatelessWidget {
       downloaded = progress.cumulativeBytesLoaded;
     }
     return progressIndicatorBuilder!(
-        context, imageUrl, DownloadProgress(imageUrl, totalSize, downloaded));
+      context,
+      imageUrl,
+      DownloadProgress(imageUrl, totalSize, downloaded),
+    );
   }
 
   Widget _octoErrorBuilder(

--- a/cached_network_image/lib/src/image_provider/_image_loader.dart
+++ b/cached_network_image/lib/src/image_provider/_image_loader.dart
@@ -4,15 +4,14 @@ import 'dart:ui' as ui;
 import 'dart:ui';
 
 import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_cache_manager/flutter_cache_manager.dart';
-
 import 'package:cached_network_image_platform_interface'
         '/cached_network_image_platform_interface.dart' as platform
     show ImageLoader;
 import 'package:cached_network_image_platform_interface'
         '/cached_network_image_platform_interface.dart'
     show ImageRenderMethodForWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
 /// ImageLoader class to load images on IO platforms.
 class ImageLoader implements platform.ImageLoader {
@@ -48,17 +47,18 @@ class ImageLoader implements platform.ImageLoader {
 
   @override
   Stream<ui.Codec> loadBufferAsync(
-      String url,
-      String? cacheKey,
-      StreamController<ImageChunkEvent> chunkEvents,
-      DecoderBufferCallback decode,
-      BaseCacheManager cacheManager,
-      int? maxHeight,
-      int? maxWidth,
-      Map<String, String>? headers,
-      Function()? errorListener,
-      ImageRenderMethodForWeb imageRenderMethodForWeb,
-      Function() evictImage) {
+    String url,
+    String? cacheKey,
+    StreamController<ImageChunkEvent> chunkEvents,
+    DecoderBufferCallback decode,
+    BaseCacheManager cacheManager,
+    int? maxHeight,
+    int? maxWidth,
+    Map<String, String>? headers,
+    Function()? errorListener,
+    ImageRenderMethodForWeb imageRenderMethodForWeb,
+    Function() evictImage,
+  ) {
     return _load(
       url,
       cacheKey,
@@ -99,21 +99,29 @@ class ImageLoader implements platform.ImageLoader {
           'maxHeight will be ignored when a normal CacheManager is used.');
 
       var stream = cacheManager is ImageCacheManager
-          ? cacheManager.getImageFile(url,
+          ? cacheManager.getImageFile(
+              url,
               maxHeight: maxHeight,
               maxWidth: maxWidth,
               withProgress: true,
               headers: headers,
-              key: cacheKey)
-          : cacheManager.getFileStream(url,
-              withProgress: true, headers: headers, key: cacheKey);
+              key: cacheKey,
+            )
+          : cacheManager.getFileStream(
+              url,
+              withProgress: true,
+              headers: headers,
+              key: cacheKey,
+            );
 
       await for (var result in stream) {
         if (result is DownloadProgress) {
-          chunkEvents.add(ImageChunkEvent(
-            cumulativeBytesLoaded: result.downloaded,
-            expectedTotalBytes: result.totalSize,
-          ));
+          chunkEvents.add(
+            ImageChunkEvent(
+              cumulativeBytesLoaded: result.downloaded,
+              expectedTotalBytes: result.totalSize,
+            ),
+          );
         }
         if (result is FileInfo) {
           var file = result.file;

--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -3,17 +3,16 @@ import 'dart:ui' as ui show Codec;
 
 import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
     show ImageRenderMethodForWeb;
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
+    if (dart.library.io) '_image_loader.dart'
+    if (dart.library.html) 'package:cached_network_image_web/cached_network_image_web.dart'
+    show ImageLoader;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
 import 'cached_network_image_provider.dart' as image_provider;
 import 'multi_image_stream_completer.dart';
-
-import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
-    if (dart.library.io) '_image_loader.dart'
-    if (dart.library.html) 'package:cached_network_image_web/cached_network_image_web.dart'
-    show ImageLoader;
 
 /// Function which is called after loading the image failed.
 typedef ErrorListener = void Function();
@@ -67,15 +66,19 @@ class CachedNetworkImageProvider
 
   @override
   Future<CachedNetworkImageProvider> obtainKey(
-      ImageConfiguration configuration) {
+    ImageConfiguration configuration,
+  ) {
     return SynchronousFuture<CachedNetworkImageProvider>(this);
   }
 
   @Deprecated(
-      'load is deprecated, use loadBuffer instead, see https://docs.flutter.dev/release/breaking-changes/image-provider-load-buffer')
+    'load is deprecated, use loadBuffer instead, see https://docs.flutter.dev/release/breaking-changes/image-provider-load-buffer',
+  )
   @override
   ImageStreamCompleter load(
-      image_provider.CachedNetworkImageProvider key, DecoderCallback decode) {
+    image_provider.CachedNetworkImageProvider key,
+    DecoderCallback decode,
+  ) {
     final chunkEvents = StreamController<ImageChunkEvent>();
     return MultiImageStreamCompleter(
       codec: _loadAsync(key, chunkEvents, decode),
@@ -92,7 +95,8 @@ class CachedNetworkImageProvider
   }
 
   @Deprecated(
-      '_loadAsync is deprecated, use loadBuffer instead, see https://docs.flutter.dev/release/breaking-changes/image-provider-load-buffer')
+    '_loadAsync is deprecated, use loadBuffer instead, see https://docs.flutter.dev/release/breaking-changes/image-provider-load-buffer',
+  )
   Stream<ui.Codec> _loadAsync(
     image_provider.CachedNetworkImageProvider key,
     StreamController<ImageChunkEvent> chunkEvents,
@@ -115,8 +119,10 @@ class CachedNetworkImageProvider
   }
 
   @override
-  ImageStreamCompleter loadBuffer(image_provider.CachedNetworkImageProvider key,
-      DecoderBufferCallback decode) {
+  ImageStreamCompleter loadBuffer(
+    image_provider.CachedNetworkImageProvider key,
+    DecoderBufferCallback decode,
+  ) {
     final chunkEvents = StreamController<ImageChunkEvent>();
     return MultiImageStreamCompleter(
       codec: _loadBufferAsync(key, chunkEvents, decode),
@@ -154,7 +160,7 @@ class CachedNetworkImageProvider
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (other is CachedNetworkImageProvider) {
       return ((cacheKey ?? url) == (other.cacheKey ?? other.url)) &&
           scale == other.scale &&

--- a/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
+++ b/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
@@ -22,25 +22,28 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
     InformationCollector? informationCollector,
   })  : _informationCollector = informationCollector,
         _scale = scale {
-    codec.listen((event) {
-      if (_timer != null) {
-        _nextImageCodec = event;
-      } else {
-        _handleCodecReady(event);
-      }
-    }, onError: (dynamic error, StackTrace stack) {
-      reportError(
-        context: ErrorDescription('resolving an image codec'),
-        exception: error,
-        stack: stack,
-        informationCollector: informationCollector,
-        silent: true,
-      );
-    });
+    codec.listen(
+      (event) {
+        if (_timer != null) {
+          _nextImageCodec = event;
+        } else {
+          _handleCodecReady(event);
+        }
+      },
+      onError: (Object error, StackTrace stack) {
+        reportError(
+          context: ErrorDescription('resolving an image codec'),
+          exception: error,
+          stack: stack,
+          informationCollector: informationCollector,
+          silent: true,
+        );
+      },
+    );
     if (chunkEvents != null) {
       chunkEvents.listen(
         reportImageChunkEvent,
-        onError: (dynamic error, StackTrace stack) {
+        onError: (Object error, StackTrace stack) {
           reportError(
             context: ErrorDescription('loading an image'),
             exception: error,
@@ -59,7 +62,7 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
   final InformationCollector? _informationCollector;
   ui.FrameInfo? _nextFrame;
   // When the current was first shown.
-  Duration? _shownTimestamp;
+  late Duration? _shownTimestamp;
   // The requested duration for the current frame;
   Duration? _frameDuration;
   // How many frames have been emitted so far.

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -2,7 +2,7 @@ name: cached_network_image
 description: Flutter library to load and cache network images.
   Can also be used with placeholder and error widgets.
 homepage: https://github.com/Baseflow/flutter_cached_network_image
-version: 3.2.2
+version: 3.2.3
 
 dependencies:
   flutter:

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -2,7 +2,7 @@ name: cached_network_image
 description: Flutter library to load and cache network images.
   Can also be used with placeholder and error widgets.
 homepage: https://github.com/Baseflow/flutter_cached_network_image
-version: 3.2.3
+version: 3.2.4
 
 dependencies:
   flutter:

--- a/cached_network_image/test/fake_cache_manager.dart
+++ b/cached_network_image/test/fake_cache_manager.dart
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:file/memory.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:mocktail/mocktail.dart';
-import 'dart:async';
 
 class FakeCacheManager extends Mock implements CacheManager {
   void throwsNotFound(String url) {
@@ -62,7 +62,7 @@ class FakeCacheManager extends Mock implements CacheManager {
     for (var chunk in chunks) {
       downloaded += chunk.length;
       if (delayBetweenChunks != null) {
-        await Future.delayed(delayBetweenChunks);
+        await Future<void>.delayed(delayBetweenChunks);
       }
       yield DownloadProgress(url, totalSize, downloaded);
     }
@@ -117,7 +117,7 @@ class FakeImageCacheManager extends Mock implements ImageCacheManager {
     for (var chunk in chunks) {
       downloaded += chunk.length;
       if (delayBetweenChunks != null) {
-        await Future.delayed(delayBetweenChunks);
+        await Future<void>.delayed(delayBetweenChunks);
       }
       yield DownloadProgress(url, totalSize, downloaded);
     }

--- a/cached_network_image/test/image_widget_test.dart
+++ b/cached_network_image/test/image_widget_test.dart
@@ -177,7 +177,7 @@ class MyImageWidget extends StatelessWidget {
 
   static LoadingErrorWidgetBuilder? getErrorBuilder(VoidCallback? onError) {
     if (onError == null) return null;
-    return (context, error, stacktrace) {
+    return (context, url, error) {
       onError();
       return const Icon(Icons.error);
     };


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? 
- Feature

### :arrow_heading_down: What is the current behavior?

In LoadingErrorWidgetBuilder in this library uses the `dynamic` type for an error when it is passed here from _octoErrorBuilder(which in turn is passed from the octo_image package in which error is of type `Object`).

### :new: What is the new behavior (if this is a feature change)?

In LoadingErrorWidgetBuilder I replace `dynamic` type with the `Object` type.

### :boom: Does this PR introduce a breaking change?

No, because the `Object` type does not conflict with anything type when it is replaced by `dynamic`.

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop