### PR TITLE
Don't forget to pass the cache key to the download function

### DIFF
--- a/cached_network_image_web/lib/cached_network_image_web.dart
+++ b/cached_network_image_web/lib/cached_network_image_web.dart
@@ -124,7 +124,7 @@ class ImageLoader implements platform.ImageLoader {
   ) async* {
     try {
       await for (var result in cacheManager.getFileStream(url,
-          withProgress: true, headers: headers)) {
+          key: cacheKey, withProgress: true, headers: headers)) {
         if (result is DownloadProgress) {
           chunkEvents.add(ImageChunkEvent(
             cumulativeBytesLoaded: result.downloaded,


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Url is passed as key to the download function

### :new: What is the new behavior (if this is a feature change)?
Pass the original cache key to the download function

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Put a breakpoint to WebHelper.downloadFile

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop