### PR TITLE
Example: bump baseflow_plugin_template & adapt to asset changes

### DIFF
--- a/cached_network_image/example/pubspec.yaml
+++ b/cached_network_image/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   baseflow_plugin_template:
     git:
       url: https://github.com/Baseflow/baseflow_plugin_template.git
-      ref: 922aa52773308bec29f0cfa2661b43ecdedd50c5
+      ref: 1c0d900deb6a25651e5c37685929813900407d3c
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -35,8 +35,3 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  assets:
-    - packages/baseflow_plugin_template/logo.png
-    - packages/baseflow_plugin_template/poweredByBaseflow.png


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bumps the `baseflow_plugin_template` Git dependency of the example to the latest revision which is compatible with Flutter 3.10.

### :arrow_heading_down: What is the current behavior?

Running the example with Flutter 3.10:

```
ERROR: ../../../../../.pub-cache/git/baseflow_plugin_template-922aa52773308bec29f0cfa2661b43ecdedd50c5/lib/src/app.dart:33:9: Error: No named parameter with the name 'accentColor'.
app.dart:33
ERROR:         accentColor: Colors.white60,

ERROR:         ^^^^^^^^^^^
```

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the example app with Flutter 3.10

### :memo: Links to relevant issues/docs

- https://github.com/Baseflow/baseflow_plugin_template/pull/5

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop