### PR TITLE
Add missing error listener to MultiImageStreamCompleter

### DIFF
--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -74,7 +74,7 @@ class CachedNetworkImageProvider
     DecoderBufferCallback decode,
   ) {
     final chunkEvents = StreamController<ImageChunkEvent>();
-    return MultiImageStreamCompleter(
+    final imageStreamCompleter = MultiImageStreamCompleter(
       codec: _loadBufferAsync(key, chunkEvents, decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
@@ -86,6 +86,19 @@ class CachedNetworkImageProvider
         );
       },
     );
+
+    if (errorListener != null) {
+      imageStreamCompleter.addListener(
+        ImageStreamListener(
+          (image, synchronousCall) {},
+          onError: (Object error, StackTrace? trace) {
+            errorListener?.call(error);
+          },
+        ),
+      );
+    }
+
+    return imageStreamCompleter;
   }
 
   @Deprecated('_loadBufferAsync is deprecated, use _loadImageAsync instead')
@@ -116,7 +129,7 @@ class CachedNetworkImageProvider
     ImageDecoderCallback decode,
   ) {
     final chunkEvents = StreamController<ImageChunkEvent>();
-    return MultiImageStreamCompleter(
+    final imageStreamCompleter = MultiImageStreamCompleter(
       codec: _loadImageAsync(key, chunkEvents, decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
@@ -128,6 +141,19 @@ class CachedNetworkImageProvider
         );
       },
     );
+
+    if (errorListener != null) {
+      imageStreamCompleter.addListener(
+        ImageStreamListener(
+          (image, synchronousCall) {},
+          onError: (Object error, StackTrace? trace) {
+            errorListener?.call(error);
+          },
+        ),
+      );
+    }
+
+    return imageStreamCompleter;
   }
 
   Stream<ui.Codec> _loadImageAsync(


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This is a bug fix that adds the optional error listener from the `CachedNetworkImageProvider` as a listener to the the `MultiImageStreamCompleter`.


### :arrow_heading_down: What is the current behavior?

Currently the `MultiImageStreamCompleter` is reporting any image errors to flutter as the error listener is not passed down correctly from the widget. When an application integrates with a observability tool like sentry or crashlytics this causes a lot of irrelevant/non-fatal errors to show up. 

### :new: What is the new behavior (if this is a feature change)?

Through registering the error listener correctly users can provide their own error handling and tracking. If a custom error listener is provided the `ImageStreamCompleter` does not report errors to flutter.

### :boom: Does this PR introduce a breaking change?

Not to my knowledge. The error listener is just added if is provided by the user. Otherwise the behavior stays the same.

### :bug: Recommendations for testing
Generate an error (http error) with an error listener passed in the widget.

### :memo: Links to relevant issues/docs

Relevant line inside flutter that reports an error if it is not handled through a listener [here](https://github.com/flutter/flutter/blob/7f20e5d18ce4cb80c621533090a7c5113f5bdc52/packages/flutter/lib/src/painting/image_stream.dart#L797).

```
for (final ImageErrorListener errorListener in localErrorListeners) {
      try {
        errorListener(exception, stack);
        handled = true;
      } catch (newException, newStack) {
        if (newException != exception) {
          FlutterError.reportError(
            FlutterErrorDetails(
              context: ErrorDescription('when reporting an error to an image listener'),
              library: 'image resource service',
              exception: newException,
              stack: newStack,
            ),
          );
        }
      }
    }
    if (!handled) {
      FlutterError.reportError(_currentError!);
    }
```

Connects to https://github.com/Baseflow/flutter_cached_network_image/pull/777

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop