### PR TITLE
[Bug Fix] Fix rethrowing error when fail

### DIFF
--- a/cached_network_image/lib/src/image_provider/_image_loader.dart
+++ b/cached_network_image/lib/src/image_provider/_image_loader.dart
@@ -138,8 +138,11 @@ class ImageLoader implements platform.ImageLoader {
         evictImage();
       });
 
-      errorListener?.call(e);
-      rethrow;
+      if (errorListener != null) {
+        errorListener(e);
+      } else {
+        rethrow;
+      }
     } finally {
       await chunkEvents.close();
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug Fix


### :arrow_heading_down: What is the current behavior?

The app crash when user has bad connection.


### :new: What is the new behavior (if this is a feature change)?

The app won't crash if user has assign errorListener to the widget


### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

https://github.com/Baseflow/flutter_cached_network_image/issues/830
https://github.com/Baseflow/flutter_cached_network_image/issues/830#issuecomment-1866820665

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop