### PR TITLE
Remove duplicate error reporting

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.3.1] - 2023-12-31
+* Adding an errorListener prevents automatic reporting to global error handler.
+
 ## [3.3.0] - 2023-09-25
 * Add error to ErrorListener
 * Update to Dart 3

--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:baseflow_plugin_template/baseflow_plugin_template.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
@@ -106,6 +108,13 @@ class BasicContent extends StatelessWidget {
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
+                errorListener: (e) {
+                  if (e is SocketException) {
+                    print('Error with ${e.address} and message ${e.message}');
+                  } else {
+                    print('Image Exception is: ${e.runtimeType}');
+                  }
+                },
               ),
             ),
             _sizedContainer(

--- a/cached_network_image/lib/src/image_provider/_image_loader.dart
+++ b/cached_network_image/lib/src/image_provider/_image_loader.dart
@@ -23,7 +23,6 @@ class ImageLoader implements platform.ImageLoader {
     int? maxHeight,
     int? maxWidth,
     Map<String, String>? headers,
-    VoidCallback? errorListener,
     ImageRenderMethodForWeb imageRenderMethodForWeb,
     VoidCallback evictImage,
   ) {
@@ -39,7 +38,6 @@ class ImageLoader implements platform.ImageLoader {
       maxHeight,
       maxWidth,
       headers,
-      (_) => errorListener?.call(),
       imageRenderMethodForWeb,
       evictImage,
     );
@@ -55,7 +53,6 @@ class ImageLoader implements platform.ImageLoader {
     int? maxHeight,
     int? maxWidth,
     Map<String, String>? headers,
-    ErrorListener? errorListener,
     ImageRenderMethodForWeb imageRenderMethodForWeb,
     VoidCallback evictImage,
   ) {
@@ -71,7 +68,6 @@ class ImageLoader implements platform.ImageLoader {
       maxHeight,
       maxWidth,
       headers,
-      errorListener,
       imageRenderMethodForWeb,
       evictImage,
     );
@@ -86,7 +82,6 @@ class ImageLoader implements platform.ImageLoader {
     int? maxHeight,
     int? maxWidth,
     Map<String, String>? headers,
-    ErrorListener? errorListener,
     ImageRenderMethodForWeb imageRenderMethodForWeb,
     VoidCallback evictImage,
   ) async* {
@@ -137,8 +132,6 @@ class ImageLoader implements platform.ImageLoader {
       scheduleMicrotask(() {
         evictImage();
       });
-
-      errorListener?.call(e);
       rethrow;
     } finally {
       await chunkEvents.close();

--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -117,7 +117,6 @@ class CachedNetworkImageProvider
       maxHeight,
       maxWidth,
       headers,
-      () => errorListener,
       imageRenderMethodForWeb,
       () => PaintingBinding.instance.imageCache.evict(key),
     );
@@ -171,7 +170,6 @@ class CachedNetworkImageProvider
       maxHeight,
       maxWidth,
       headers,
-      errorListener,
       imageRenderMethodForWeb,
       () => PaintingBinding.instance.imageCache.evict(key),
     );

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -6,14 +6,14 @@ topics:
   - cache
   - image
   - network-image
-version: 3.3.0
+version: 3.3.1
 environment:
   sdk: ^3.0.0
   flutter: '>=3.10.0'
 
 dependencies:
-  cached_network_image_platform_interface: ^3.0.0
-  cached_network_image_web: ^1.1.0
+  cached_network_image_platform_interface: ^4.0.0
+  cached_network_image_web: ^1.1.1
   flutter:
     sdk: flutter
   flutter_cache_manager: ^3.3.1

--- a/cached_network_image_platform_interface/CHANGELOG.md
+++ b/cached_network_image_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [4.0.0] - 2023-12-31
+* Removed errorListener from ImageLoader interface
+
 ## [3.0.0] - 2023-09-25
 * Add error to ErrorListener
 * Specify types

--- a/cached_network_image_platform_interface/lib/cached_network_image_platform_interface.dart
+++ b/cached_network_image_platform_interface/lib/cached_network_image_platform_interface.dart
@@ -35,7 +35,6 @@ class ImageLoader {
     int? maxHeight,
     int? maxWidth,
     Map<String, String>? headers,
-    VoidCallback? errorListener,
     ImageRenderMethodForWeb imageRenderMethodForWeb,
     VoidCallback evictImage,
   ) {
@@ -53,7 +52,6 @@ class ImageLoader {
     int? maxHeight,
     int? maxWidth,
     Map<String, String>? headers,
-    ErrorListener? errorListener,
     ImageRenderMethodForWeb imageRenderMethodForWeb,
     VoidCallback evictImage,
   ) {

--- a/cached_network_image_platform_interface/pubspec.yaml
+++ b/cached_network_image_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cached_network_image_platform_interface
 description: Platform interface for CachedNetworkImage
-version: 3.0.0
+version: 4.0.0
 homepage: https://github.com/Baseflow/flutter_cached_network_image
 
 environment:

--- a/cached_network_image_platform_interface/test/cached_network_image_platform_interface_test.dart
+++ b/cached_network_image_platform_interface/test/cached_network_image_platform_interface_test.dart
@@ -25,7 +25,6 @@ void main() {
           null,
           null,
           null,
-          null,
           ImageRenderMethodForWeb.HttpGet,
           () => {},
         ),

--- a/cached_network_image_web/CHANGELOG.md
+++ b/cached_network_image_web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.1.1] - 2023-12-31
+* Removed errorListener from ImageLoader interface
+
 ## [1.1.0] - 2023-09-25
 * Add error to ErrorListener
 * Specify types

--- a/cached_network_image_web/lib/cached_network_image_web.dart
+++ b/cached_network_image_web/lib/cached_network_image_web.dart
@@ -7,7 +7,7 @@ import 'dart:ui' as ui;
 
 import 'package:cached_network_image_platform_interface'
         '/cached_network_image_platform_interface.dart' as platform
-    show ImageLoader, ErrorListener, ImageRenderMethodForWeb;
+    show ImageLoader, ImageRenderMethodForWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
@@ -24,7 +24,6 @@ class ImageLoader implements platform.ImageLoader {
     int? maxHeight,
     int? maxWidth,
     Map<String, String>? headers,
-    VoidCallback? errorListener,
     platform.ImageRenderMethodForWeb imageRenderMethodForWeb,
     VoidCallback evictImage,
   ) {
@@ -40,7 +39,6 @@ class ImageLoader implements platform.ImageLoader {
       maxHeight,
       maxWidth,
       headers,
-      (_) {},
       imageRenderMethodForWeb,
       evictImage,
     );
@@ -56,7 +54,6 @@ class ImageLoader implements platform.ImageLoader {
     int? maxHeight,
     int? maxWidth,
     Map<String, String>? headers,
-    ValueChanged<Object>? errorListener,
     platform.ImageRenderMethodForWeb imageRenderMethodForWeb,
     VoidCallback evictImage,
   ) {
@@ -72,7 +69,6 @@ class ImageLoader implements platform.ImageLoader {
       maxHeight,
       maxWidth,
       headers,
-      errorListener,
       imageRenderMethodForWeb,
       evictImage,
     );
@@ -87,7 +83,6 @@ class ImageLoader implements platform.ImageLoader {
     int? maxHeight,
     int? maxWidth,
     Map<String, String>? headers,
-    platform.ErrorListener? errorListener,
     platform.ImageRenderMethodForWeb imageRenderMethodForWeb,
     VoidCallback evictImage,
   ) {
@@ -102,7 +97,6 @@ class ImageLoader implements platform.ImageLoader {
           maxHeight,
           maxWidth,
           headers,
-          errorListener,
           evictImage,
         );
       case platform.ImageRenderMethodForWeb.HtmlImage:
@@ -119,7 +113,6 @@ class ImageLoader implements platform.ImageLoader {
     int? maxHeight,
     int? maxWidth,
     Map<String, String>? headers,
-    platform.ErrorListener? errorListener,
     VoidCallback evictImage,
   ) async* {
     try {
@@ -151,7 +144,6 @@ class ImageLoader implements platform.ImageLoader {
       scheduleMicrotask(() {
         evictImage();
       });
-      errorListener?.call(e);
       rethrow;
     }
     await chunkEvents.close();

--- a/cached_network_image_web/pubspec.yaml
+++ b/cached_network_image_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cached_network_image_web
 description: Web implementation of CachedNetworkImage
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/Baseflow/flutter_cached_network_image
 
 environment:
@@ -8,7 +8,7 @@ environment:
   flutter: '>=3.10.0'
 
 dependencies:
-  cached_network_image_platform_interface: ^3.0.0
+  cached_network_image_platform_interface: ^4.0.0
   flutter:
     sdk: flutter
   flutter_cache_manager: ^3.3.1

--- a/cached_network_image_web/test/cached_network_image_web_test.dart
+++ b/cached_network_image_web/test/cached_network_image_web_test.dart
@@ -24,7 +24,6 @@ void main() {
       null,
       null,
       null,
-      null,
       ImageRenderMethodForWeb.HttpGet,
       () => {},
     );


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix on new feature

### :arrow_heading_down: What is the current behavior?
After PR #891 was merged we got a duplicate error reporting. The same error is reported twice.
With reporting through the ImageStreamCompleter we should remove the extra reporting in the image loaders.

This also updates the changelogs and versions

### :new: What is the new behavior (if this is a feature change)?
Only report errors once.

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop