### PR TITLE
Fixed: Deprecated API usage 

### DIFF
--- a/cached_network_image_web/lib/cached_network_image_web.dart
+++ b/cached_network_image_web/lib/cached_network_image_web.dart
@@ -4,6 +4,7 @@ library cached_network_image_web;
 import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
+import 'dart:ui_web';
 
 import 'package:cached_network_image_platform_interface'
         '/cached_network_image_platform_interface.dart' as platform
@@ -155,7 +156,7 @@ class ImageLoader implements platform.ImageLoader {
   ) {
     final resolved = Uri.base.resolve(url);
     // ignore: undefined_function
-    return ui.webOnlyInstantiateImageCodecFromUrl(
+    return createImageCodecFromUrl(
       resolved,
       chunkCallback: (int bytes, int total) {
         chunkEvents.add(
@@ -165,7 +166,7 @@ class ImageLoader implements platform.ImageLoader {
           ),
         );
       },
-    ) as Future<ui.Codec>;
+    );
   }
 }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Removed deprecated method `webOnlyInstantiateImageCodecFromUrl`, used `createImageCodecFromUrl`

### :arrow_heading_down: What is the current behavior?
Warning, about to remove `webOnlyInstantiateImageCodecFromUrl` method

### :new: What is the new behavior (if this is a feature change)?
Replaced with `createImageCodecFromUrl`

### :boom: Does this PR introduce a breaking change?
No
### :bug: Recommendations for testing
Yes

### :memo: Links to relevant issues/docs
#906 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop