### PR TITLE
added static field defaultCacheManager to CachedNetworkImageProvider

### DIFF
--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -55,7 +55,7 @@ class CachedNetworkImage extends StatelessWidget {
     BaseCacheManager? cacheManager,
     double scale = 1,
   }) async {
-    final effectiveCacheManager = cacheManager ?? DefaultCacheManager();
+    final effectiveCacheManager = cacheManager ?? CachedNetworkImageProvider.defaultCacheManager;
     await effectiveCacheManager.removeFile(cacheKey ?? url);
     return CachedNetworkImageProvider(url, scale: scale).evict();
   }

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -55,7 +55,8 @@ class CachedNetworkImage extends StatelessWidget {
     BaseCacheManager? cacheManager,
     double scale = 1,
   }) async {
-    final effectiveCacheManager = cacheManager ?? CachedNetworkImageProvider.defaultCacheManager;
+    final effectiveCacheManager =
+        cacheManager ?? CachedNetworkImageProvider.defaultCacheManager;
     await effectiveCacheManager.removeFile(cacheKey ?? url);
     return CachedNetworkImageProvider(url, scale: scale).evict();
   }

--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -35,7 +35,7 @@ class CachedNetworkImageProvider
   final BaseCacheManager? cacheManager;
 
   /// The default cache manager used for image caching.
-  static DefaultCacheManager defaultCacheManager = DefaultCacheManager();
+  static BaseCacheManager defaultCacheManager = DefaultCacheManager();
 
   /// Web url of the image to load
   final String url;

--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -34,6 +34,9 @@ class CachedNetworkImageProvider
   /// CacheManager from which the image files are loaded.
   final BaseCacheManager? cacheManager;
 
+  /// The default cache manager used for image caching.
+  static DefaultCacheManager defaultCacheManager = DefaultCacheManager();
+
   /// Web url of the image to load
   final String url;
 
@@ -113,7 +116,7 @@ class CachedNetworkImageProvider
       cacheKey,
       chunkEvents,
       decode,
-      cacheManager ?? DefaultCacheManager(),
+      cacheManager ?? defaultCacheManager,
       maxHeight,
       maxWidth,
       headers,
@@ -166,7 +169,7 @@ class CachedNetworkImageProvider
       cacheKey,
       chunkEvents,
       decode,
-      cacheManager ?? DefaultCacheManager(),
+      cacheManager ?? defaultCacheManager,
       maxHeight,
       maxWidth,
       headers,


### PR DESCRIPTION
:sparkles: This pull request is aimed at creating the ability to globally configure the default caching manager


:arrow_heading_down: Currently, if you need to globally override the caching manager, you need to register it in the constructor of each widget. This is extremely inconvenient if the project grows, and also creates risks that the developer may forget to specify it


:new: The CachedNetworkImageProvider class now has a static field that can be defined before the application starts. It is the value of this field that will be used in the case when the user did not pass any value to the caching manager


:boom: This PR does not make global changes


:bug: It is recommended to check the work associated with switching the default cache manager while the application is running


:thinking: Pre-shipment checklist

- [ +] All build projects
- [ +] Follows style guidelines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation has been updated.
- [+ ] Reworked based on current development