### PR TITLE
Bugfix: Change how errors are reported by ImageLoader. Emits as stream instead of re-throwing

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.3.2] - 2024-04-10
+* Change how errors are reported by ImageLoader. Emitting errors as streams instead of re-throwing.
+
 ## [3.3.1] - 2023-12-31
 * Adding an errorListener prevents automatic reporting to global error handler.
 

--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -142,7 +142,7 @@ class BasicContent extends StatelessWidget {
           aspectRatio: 1.6,
           child: BlurHash(hash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj'),
         ),
-        imageUrl: 'https://blurha.sh/assets/images/img1.jpg',
+        imageUrl: 'https://blurha.sh/12c2aca29ea896a628be.jpg',
         fit: BoxFit.cover,
       ),
     );

--- a/cached_network_image/lib/src/image_provider/_image_loader.dart
+++ b/cached_network_image/lib/src/image_provider/_image_loader.dart
@@ -125,14 +125,14 @@ class ImageLoader implements platform.ImageLoader {
           yield decoded;
         }
       }
-    } on Object {
+    } on Object catch (error, stackTrace) {
       // Depending on where the exception was thrown, the image cache may not
       // have had a chance to track the key in the cache at all.
       // Schedule a microtask to give the cache a chance to add the key.
       scheduleMicrotask(() {
         evictImage();
       });
-      rethrow;
+      yield* Stream.error(error, stackTrace);
     } finally {
       await chunkEvents.close();
     }

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -6,7 +6,7 @@ topics:
   - cache
   - image
   - network-image
-version: 3.3.1
+version: 3.3.2
 environment:
   sdk: ^3.0.0
   flutter: '>=3.10.0'


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This is a bug fix

### :arrow_heading_down: What is the current behavior?
If the `CachedNetworkImageProvider` gets some error when fetching an image url, then internally the `ImageLoader` will rethrow that error. 
This leads to the unwanted behavior that you get an uncaught exception.
And this for example then leads to faulty fatal errors being reported in Crashlytics.

### :new: What is the new behavior (if this is a feature change)?
Instead of throwing the error inside the `ImageLoader`, we are now emitting the error as a stream error into the current stream.
This has the added benefit that this will not be an uncaught exception. 
And all existing ErrorListeners, ErrorBuilders will still work.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
You can test this change with the existing example app. 
If you run the example app for a mobile device and enabled the debugger to catch uncaught exceptions, then with this fix you will not get any uncaught exceptions. And before this fix, you would get uncaught exceptions for the `https://notAvalid.uri` and the `not a uri at all`.

### :memo: Links to relevant issues/docs
N/A

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop

### Screenshots
These screenshots come from VSCode running the previous version with `uncaught exceptions` turned on:
<img width="1000" alt="Screenshot 2024-04-10 at 15 16 51" src="https://github.com/Baseflow/flutter_cached_network_image/assets/59053438/1862d2d7-61b6-47bf-8255-83c3d6559011">
<img width="1000" alt="Screenshot 2024-04-10 at 15 16 57" src="https://github.com/Baseflow/flutter_cached_network_image/assets/59053438/5e859b16-3e09-4cd3-86fb-db3790e8e453">

And here is a screenshot coming from this version with `uncaught exceptions` turned on:
<img width="1000" alt="Screenshot 2024-04-10 at 15 16 14" src="https://github.com/Baseflow/flutter_cached_network_image/assets/59053438/b5b86932-59ee-474e-877b-1b6d61261a58">
