### PR TITLE
Replace deprecated `webOnlyInstantiateImageCodecFromUrl` to `createImageCodecFromUrl` from `dart:ui_web`

### DIFF
--- a/cached_network_image_web/CHANGELOG.md
+++ b/cached_network_image_web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.2.0] - 
+* Replace deprecated `webOnlyInstantiateImageCodecFromUrl` to `createImageCodecFromUrl` from `dart:ui_web`
+
 ## [1.1.1] - 2023-12-31
 * Removed errorListener from ImageLoader interface
 

--- a/cached_network_image_web/lib/cached_network_image_web.dart
+++ b/cached_network_image_web/lib/cached_network_image_web.dart
@@ -4,10 +4,10 @@ library cached_network_image_web;
 import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
+import 'dart:ui_web' as ui_web;
 
 import 'package:cached_network_image_platform_interface'
-        '/cached_network_image_platform_interface.dart' as platform
-    show ImageLoader, ImageRenderMethodForWeb;
+    '/cached_network_image_platform_interface.dart' as platform show ImageLoader, ImageRenderMethodForWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
@@ -154,8 +154,7 @@ class ImageLoader implements platform.ImageLoader {
     StreamController<ImageChunkEvent> chunkEvents,
   ) {
     final resolved = Uri.base.resolve(url);
-    // ignore: undefined_function
-    return ui.webOnlyInstantiateImageCodecFromUrl(
+    return ui_web.createImageCodecFromUrl(
       resolved,
       chunkCallback: (int bytes, int total) {
         chunkEvents.add(
@@ -165,7 +164,7 @@ class ImageLoader implements platform.ImageLoader {
           ),
         );
       },
-    ) as Future<ui.Codec>;
+    );
   }
 }
 

--- a/cached_network_image_web/lib/cached_network_image_web.dart
+++ b/cached_network_image_web/lib/cached_network_image_web.dart
@@ -7,8 +7,9 @@ import 'dart:ui' as ui;
 import 'dart:ui_web' as ui_web;
 
 import 'package:cached_network_image_platform_interface'
-    '/cached_network_image_platform_interface.dart' as platform show ImageLoader, ImageRenderMethodForWeb;
-import 'package:flutter/material.dart';
+        '/cached_network_image_platform_interface.dart' as platform
+    show ImageLoader, ImageRenderMethodForWeb;
+import 'package:flutter/rendering.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
 /// ImageLoader class to load images on the web platform.

--- a/cached_network_image_web/pubspec.yaml
+++ b/cached_network_image_web/pubspec.yaml
@@ -1,10 +1,10 @@
 name: cached_network_image_web
 description: Web implementation of CachedNetworkImage
-version: 1.1.1
+version: 1.2.0
 homepage: https://github.com/Baseflow/flutter_cached_network_image
 
 environment:
-  sdk: ^3.0.0
+  sdk: '>=3.0.0 <4.0.0'
   flutter: '>=3.10.0'
 
 dependencies:
@@ -15,6 +15,6 @@ dependencies:
 
 dev_dependencies:
   file: '>=6.1.4 <8.0.0'
-  flutter_lints: ^2.0.3
+  flutter_lints: '>=2.0.3 <4.0.0'
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
```
The webOnlyInstantiateImageCodecFromUrl API is deprecated and will be removed in a future release. Please use `createImageCodecFromUrl` from `dart:ui_web` instead.
```


### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Replace deprecated function to new

### :boom: Does this PR introduce a breaking change?
No

### :memo: Links to relevant issues/docs
#890
#906

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop