### PR TITLE
Improved debug console messages

### DIFF
--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -78,13 +78,10 @@ class CachedNetworkImageProvider
       codec: _loadBufferAsync(key, chunkEvents, decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
-      informationCollector: () sync* {
-        yield DiagnosticsProperty<ImageProvider>(
-          'Image provider: $this \n Image key: $key',
-          this,
-          style: DiagnosticsTreeStyle.errorProperty,
-        );
-      },
+      informationCollector: () => <DiagnosticsNode>[
+        DiagnosticsProperty<ImageProvider>('Image provider', this),
+        DiagnosticsProperty<CachedNetworkImageProvider>('Image key', key),
+      ],
     );
 
     if (errorListener != null) {
@@ -132,13 +129,10 @@ class CachedNetworkImageProvider
       codec: _loadImageAsync(key, chunkEvents, decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
-      informationCollector: () sync* {
-        yield DiagnosticsProperty<ImageProvider>(
-          'Image provider: $this \n Image key: $key',
-          this,
-          style: DiagnosticsTreeStyle.errorProperty,
-        );
-      },
+      informationCollector: () => <DiagnosticsNode>[
+        DiagnosticsProperty<ImageProvider>('Image provider', this),
+        DiagnosticsProperty<CachedNetworkImageProvider>('Image key', key),
+      ],
     );
 
     if (errorListener != null) {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Improved debug console messages. References from [NetworkImage of flutter](https://github.com/flutter/flutter/blob/e8d4c98b07f84c281dd39fb70a7bf7ee2f8154ae/packages/flutter/lib/src/painting/_network_image_io.dart#L51-L54).

```dart
informationCollector: () => <DiagnosticsNode>[
  DiagnosticsProperty<image_provider.ImageProvider>('Image provider', this),
  DiagnosticsProperty<image_provider.NetworkImage>('Image key', key),
],
```

### :arrow_heading_down: What is the current behavior?

```
======== Exception caught by image resource service ================================================
The following HttpExceptionWithStatus was thrown resolving an image codec:
HttpException: Invalid statusCode: 404, uri = https://blurha.sh/assets/images/img1.jpg

When the exception was thrown, this was the stack: 
Image provider: CachedNetworkImageProvider("https://blurha.sh/assets/images/img1.jpg", scale: 1.0) 
 Image key: CachedNetworkImageProvider("https://blurha.sh/assets/images/img1.jpg", scale: 1.0): CachedNetworkImageProvider("https://blurha.sh/assets/images/img1.jpg", scale: 1.0)
====================================================================================================
```

### :new: What is the new behavior (if this is a feature change)?

```
======== Exception caught by image resource service ================================================
The following HttpExceptionWithStatus was thrown resolving an image codec:
HttpException: Invalid statusCode: 404, uri = https://blurha.sh/assets/images/img1.jpg

When the exception was thrown, this was the stack: 
Image provider: CachedNetworkImageProvider("https://blurha.sh/assets/images/img1.jpg", scale: 1.0)
Image key: CachedNetworkImageProvider("https://blurha.sh/assets/images/img1.jpg", scale: 1.0)
====================================================================================================
```

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

N/A

### :memo: Links to relevant issues/docs

N/A

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop