### PR TITLE
Adds `debugLabel` for the image stream completer

### DIFF
--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -81,6 +81,7 @@ class CachedNetworkImageProvider
       codec: _loadBufferAsync(key, chunkEvents, decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
+      debugLabel: key.url,
       informationCollector: () => <DiagnosticsNode>[
         DiagnosticsProperty<ImageProvider>('Image provider', this),
         DiagnosticsProperty<CachedNetworkImageProvider>('Image key', key),
@@ -132,6 +133,7 @@ class CachedNetworkImageProvider
       codec: _loadImageAsync(key, chunkEvents, decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
+      debugLabel: key.url,
       informationCollector: () => <DiagnosticsNode>[
         DiagnosticsProperty<ImageProvider>('Image provider', this),
         DiagnosticsProperty<CachedNetworkImageProvider>('Image key', key),

--- a/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
+++ b/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
@@ -18,10 +18,12 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
   MultiImageStreamCompleter({
     required Stream<ui.Codec> codec,
     required double scale,
+    String? debugLabel,
     Stream<ImageChunkEvent>? chunkEvents,
     InformationCollector? informationCollector,
   })  : _informationCollector = informationCollector,
         _scale = scale {
+    this.debugLabel = debugLabel;
     codec.listen(
       (event) {
         if (_timer != null) {

--- a/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
+++ b/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
@@ -103,7 +103,13 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
     _frameCallbackScheduled = false;
     if (!hasListeners) return;
     if (_isFirstFrame() || _hasFrameDurationPassed(timestamp)) {
-      _emitFrame(ImageInfo(image: _nextFrame!.image, scale: _scale));
+      _emitFrame(
+        ImageInfo(
+          image: _nextFrame!.image,
+          scale: _scale,
+          debugLabel: debugLabel,
+        ),
+      );
       _shownTimestamp = timestamp;
       _frameDuration = _nextFrame!.duration;
       _nextFrame = null;
@@ -153,7 +159,13 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
 
       // This is not an animated image, just return it and don't schedule more
       // frames.
-      _emitFrame(ImageInfo(image: _nextFrame!.image, scale: _scale));
+      _emitFrame(
+        ImageInfo(
+          image: _nextFrame!.image,
+          scale: _scale,
+          debugLabel: debugLabel,
+        ),
+      );
       return;
     }
     _scheduleAppFrame();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This is a bug fix. Fixes #973

This also helps to display the info in the Flutter Inspector.

As a reference, this is how the `MultiFrameImageStreamCompleter` implements the `debugLevel`.
https://github.com/flutter/flutter/blob/574b7e765d86f3f70eac8817a2906ac3099c0bf9/packages/flutter/lib/src/painting/image_stream.dart#L967

### :arrow_heading_down: What is the current behavior?

```console
======== Exception caught by painting library ======================================================
The following message was thrown while painting an image:
Image null has a display size of 794×529 but a decode size of 1956×1280, which uses an additional 10849KB (assuming a device pixel ratio of 2.625).

Consider resizing the asset ahead of time, supplying a cacheWidth parameter of 794, a cacheHeight parameter of 529, or using a ResizeImage.
```

### :new: What is the new behavior (if this is a feature change)?

```console
======== Exception caught by painting library ======================================================
The following message was thrown while painting an image:
Image https://example.com/redact.jpeg has a display size of 794×529 but a decode size of 1956×1280, which uses an additional 10849KB (assuming a device pixel ratio of 2.625).

Consider resizing the asset ahead of time, supplying a cacheWidth parameter of 794, a cacheHeight parameter of 529, or using a ResizeImage.
```

### :boom: Does this PR introduce a breaking change?

No.
