### PR TITLE
GIF image set minimum frame duration (-> 100ms)

### DIFF
--- a/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
+++ b/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
@@ -104,6 +104,11 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
       _emitFrame(ImageInfo(image: _nextFrame!.image, scale: _scale));
       _shownTimestamp = timestamp;
       _frameDuration = _nextFrame!.duration;
+
+      if (_frameDuration! <= const Duration(milliseconds: 10)) {
+        _frameDuration = const Duration(milliseconds: 100);
+      }
+
       _nextFrame = null;
       if (_framesEmitted % _codec!.frameCount == 0 && _nextImageCodec != null) {
         _switchToNewCodec();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
* Adds a configuration option to set the minimum frame time for GIF images.

~~~dart
  if (_frameDuration! <= const Duration(milliseconds: 10)) {
    _frameDuration = const Duration(milliseconds: 100);
  }
~~~
> in `multi_image_stream_completer.dart`

### :arrow_heading_down: What is the current behavior?

* Currently, GIF images do not have a configurable minimum frame time, which can lead to inconsistent or overly rapid playback on some devices.


### :new: What is the new behavior (if this is a feature change)?

* This PR introduces a feature to configure the minimum frame time for GIF images, allowing smoother playback and control over animation speed, especially on platforms that impose minimum frame rate limits.



https://github.com/user-attachments/assets/d7b0017f-171e-4776-8ac5-58c86798713d

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Test GIF playback with various minimum frame times to ensure the configuration functions as expected.
Confirm that the feature works across different devices and platforms, including browsers with built-in frame rate limits like Chrome.

### :memo: Links to relevant issues/docs

* the Chrome browser enforces a minimum GIF frame time of 100ms by default, which limits playback speed for faster animations. (See [source](https://source.chromium.org/chromium/chromium/src/+/refs/tags/98.0.4754.1:third_party/blink/renderer/platform/graphics/deferred_image_decoder.cc;l=353))

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop