### PR TITLE
Set `ImageRenderMethodForWeb.HttpGet,` as a default `imageRenderMethodForWeb` for flutter 3.27.0 compatibility workaround

### DIFF
--- a/cached_network_image/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/cached_network_image/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import path_provider_foundation
-import sqflite
+import sqflite_darwin
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -240,7 +240,7 @@ class CachedNetworkImage extends StatelessWidget {
     this.maxHeightDiskCache,
     this.errorListener,
     ImageRenderMethodForWeb imageRenderMethodForWeb =
-        ImageRenderMethodForWeb.HtmlImage,
+        ImageRenderMethodForWeb.HttpGet,
     double scale = 1.0,
   }) : _image = CachedNetworkImageProvider(
           imageUrl,

--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -3,11 +3,11 @@ import 'dart:ui' as ui show Codec;
 
 import 'package:cached_network_image/src/image_provider/multi_image_stream_completer.dart';
 import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
-    show ErrorListener, ImageRenderMethodForWeb;
-import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
     if (dart.library.io) '_image_loader.dart'
     if (dart.library.js_interop) 'package:cached_network_image_web/cached_network_image_web.dart'
     show ImageLoader;
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
+    show ErrorListener, ImageRenderMethodForWeb;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -28,7 +28,7 @@ class CachedNetworkImageProvider
     this.headers,
     this.cacheManager,
     this.cacheKey,
-    this.imageRenderMethodForWeb = ImageRenderMethodForWeb.HtmlImage,
+    this.imageRenderMethodForWeb = ImageRenderMethodForWeb.HttpGet,
   });
 
   /// CacheManager from which the image files are loaded.

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -10,7 +10,7 @@ version: 3.4.1
 
 environment:
   sdk: ^3.0.0
-  flutter: '>=3.10.0'
+  flutter: ">=3.10.0"
 
 dependencies:
   cached_network_image_platform_interface: ^4.1.1
@@ -21,7 +21,7 @@ dependencies:
   octo_image: ^2.1.0
 
 dev_dependencies:
-  file: '>=7.0.0 <8.0.0'
+  file: ">=7.0.0 <8.0.0"
   flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter

--- a/cached_network_image_platform_interface/pubspec.yaml
+++ b/cached_network_image_platform_interface/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Baseflow/flutter_cached_network_image
 
 environment:
   sdk: ^3.0.0
-  flutter: '>=3.10.0'
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:
@@ -13,7 +13,7 @@ dependencies:
   flutter_cache_manager: ^3.4.1
 
 dev_dependencies:
-  file: '>=7.0.0 <8.0.0'
+  file: ">=7.0.0 <8.0.0"
   flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter

--- a/cached_network_image_web/pubspec.yaml
+++ b/cached_network_image_web/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Baseflow/flutter_cached_network_image
 
 environment:
   sdk: ^3.0.0
-  flutter: '>=3.10.0'
+  flutter: ">=3.10.0"
 
 dependencies:
   cached_network_image_platform_interface: ^4.1.1
@@ -15,7 +15,7 @@ dependencies:
   web: ^1.0.0
 
 dev_dependencies:
-  file: '>=7.0.0 <8.0.0'
+  file: ">=7.0.0 <8.0.0"
   flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Set `ImageRenderMethodForWeb.HttpGet,` as a default `imageRenderMethodForWeb` for flutter 3.27.0 compatibility workaround

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Workaround

### :arrow_heading_down: What is the current behavior?
Currently on flutter version 3.27.0, usage of cached_network_image causes `canvaskit.js:21 Uncaught (in promise) SecurityError: Failed to execute 'texImage2D' on 'WebGL2RenderingContext': The image element contains cross-origin data, and may not be loaded.` errors

### :new: What is the new behavior (if this is a feature change)?
Setting the `ImageRenderMethodForWeb.HttpGet,` as a default `imageRenderMethodForWeb` prevents the errors from being thrown, and the app doesn't crash.

### :boom: Does this PR introduce a breaking change?
Yes, the default value is being changed, which can cause unexpected behavior on older flutter versions

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
[https://github.com/Baseflow/flutter_cached_network_image/issues/995](url)
[https://github.com/flutter/flutter/issues/160127](url)

### :thinking: Checklist before submitting

- [yes] All projects build
- [yes] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [no] Relevant documentation was updated
- [yes] Rebased onto current develop