### PR TITLE
Chore migrate to gradle v 8.3

### DIFF
--- a/cached_network_image/example/.metadata
+++ b/cached_network_image/example/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "b0850beeb25f6d5b10426284f506557f66181b36"
+  revision: "17025dd88227cd9532c33fa78f5250d548d87e9a"
   channel: "stable"
 
 project_type: app
@@ -13,8 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: b0850beeb25f6d5b10426284f506557f66181b36
-      base_revision: b0850beeb25f6d5b10426284f506557f66181b36
+      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+    - platform: android
+      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+    - platform: ios
+      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+    - platform: linux
+      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+    - platform: macos
+      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+    - platform: web
+      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+    - platform: windows
+      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
 
   # User provided section
 

--- a/cached_network_image/example/android/.gitignore
+++ b/cached_network_image/example/android/.gitignore
@@ -7,7 +7,7 @@ gradle-wrapper.jar
 GeneratedPluginRegistrant.java
 
 # Remember to never publicly share your keystore.
-# See https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app
+# See https://flutter.dev/to/reference-keystore
 key.properties
 **/*.keystore
 **/*.jks

--- a/cached_network_image/example/android/app/build.gradle
+++ b/cached_network_image/example/android/app/build.gradle
@@ -5,24 +5,6 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file("local.properties")
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader("UTF-8") { reader ->
-        localProperties.load(reader)
-    }
-}
-
-def flutterVersionCode = localProperties.getProperty("flutter.versionCode")
-if (flutterVersionCode == null) {
-    flutterVersionCode = "1"
-}
-
-def flutterVersionName = localProperties.getProperty("flutter.versionName")
-if (flutterVersionName == null) {
-    flutterVersionName = "1.0"
-}
-
 android {
     namespace = "com.example.example"
     compileSdk = flutter.compileSdkVersion
@@ -33,15 +15,19 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "com.example.example"
         // You can update the following values to match your application needs.
-        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
+        // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
-        versionCode = flutterVersionCode.toInteger()
-        versionName = flutterVersionName
+        versionCode = flutter.versionCode
+        versionName = flutter.versionName
     }
 
     buildTypes {

--- a/cached_network_image/example/android/gradle.properties
+++ b/cached_network_image/example/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx4G -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true

--- a/cached_network_image/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/cached_network_image/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip

--- a/cached_network_image/example/android/settings.gradle
+++ b/cached_network_image/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version "8.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 
 include ":app"

--- a/cached_network_image/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/cached_network_image/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import path_provider_foundation
-import sqflite
+import sqflite_darwin
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {


### PR DESCRIPTION
This pull request includes various updates and improvements across multiple files in the `cached_network_image` example project. The primary changes involve updating revision references, modifying build configurations, and updating dependencies.

### Revision Updates:
* [`cached_network_image/example/.metadata`](diffhunk://#diff-fe879141acd6a8e81756e1deb75b7e810b56df0ab62f74c18796167ce5ed4efdL7-R7): Updated the revision and platform create/base revisions to "17025dd88227cd9532c33fa78f5250d548d87e9a". [[1]](diffhunk://#diff-fe879141acd6a8e81756e1deb75b7e810b56df0ab62f74c18796167ce5ed4efdL7-R7) [[2]](diffhunk://#diff-fe879141acd6a8e81756e1deb75b7e810b56df0ab62f74c18796167ce5ed4efdL16-R35)

### Build Configuration Changes:
* [`cached_network_image/example/android/app/build.gradle`](diffhunk://#diff-141f7a2e312891e3500be467b006ea46cb1c36b24d90f9d28ad5d9e7c9345a77L8-L25): Removed local properties related to `flutterVersionCode` and `flutterVersionName`, and updated references to use `flutter.versionCode` and `flutter.versionName`. Added `kotlinOptions` for JVM target compatibility. [[1]](diffhunk://#diff-141f7a2e312891e3500be467b006ea46cb1c36b24d90f9d28ad5d9e7c9345a77L8-L25) [[2]](diffhunk://#diff-141f7a2e312891e3500be467b006ea46cb1c36b24d90f9d28ad5d9e7c9345a77R18-R30)
* [`cached_network_image/example/android/gradle.properties`](diffhunk://#diff-67ee4c1b34a18c8bcec214c339b8d4eb9c01e895787043b1073f460f7d9a5974L1-R1): Modified JVM arguments to include `MaxMetaspaceSize=2G`.
* [`cached_network_image/example/android/gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-a97d55c432a41e02c2ac5ed824db3d6a545ca0dd4d625c2d56738d466f1e9dc0L5-R5): Updated the Gradle distribution URL to use version 8.3.

### Dependency Updates:
* [`cached_network_image/example/android/settings.gradle`](diffhunk://#diff-fd29b772721c6429615085deeb062ba16bd84f971c7d1f997e5832b705903f35L21-R22): Updated the versions for `com.android.application` to 8.1.0 and `org.jetbrains.kotlin.android` to 1.8.22.
* [`cached_network_image/example/macos/Flutter/GeneratedPluginRegistrant.swift`](diffhunk://#diff-6f9f286c0a672cd404fd0e58b7d6dc3750f2cf313b8c12b3c6fee063d3c40597L9-R9): Replaced `sqflite` with `sqflite_darwin`.

### Documentation Updates:
* [`cached_network_image/example/android/.gitignore`](diffhunk://#diff-21ed943ede097fd33a185a5658f254f5b9a73e26cf2f041100e916cda7d6008dL10-R10): Updated the link for referencing the keystore.