### PR TITLE
chore: Exports ImageRenderMethodForWeb

### DIFF
--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -11,6 +11,8 @@ import 'package:cached_network_image_platform_interface/cached_network_image_pla
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+export 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
+    show ImageRenderMethodForWeb;
 
 /// IO implementation of the CachedNetworkImageProvider; the ImageProvider to
 /// load network images using a cache.


### PR DESCRIPTION
Allow external configuration

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
DX improvement

### :arrow_heading_down: What is the current behavior?
when attempting to configure the `imageRenderMethodForWeb` property of `CachedNetworkImageProvider`, the required **ImageRenderMethodForWeb** enum is inaccessible.

### :new: What is the new behavior (if this is a feature change)?
**ImageRenderMethodForWeb** enum is now publicly exported, allowing consumers to configure the `imageRenderMethodForWeb` property.

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
n/a

### :memo: Links to relevant issues/docs
#1003

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop