### PR TITLE
Prevent repeated load attempts after image decode failures

### DIFF
--- a/cached_network_image/lib/src/image_provider/_image_loader.dart
+++ b/cached_network_image/lib/src/image_provider/_image_loader.dart
@@ -121,7 +121,16 @@ class ImageLoader implements platform.ImageLoader {
         if (result is FileInfo) {
           final file = result.file;
           final bytes = await file.readAsBytes();
-          final decoded = await decode(bytes);
+          ui.Codec decoded;
+          try {
+            decoded = await decode(bytes);
+          } catch (e, stackTrace) {
+            // The cached data is not a valid image, so it cannot be decoded.
+            // Remove it and forward the error to display the errorWidget.
+            await cacheManager.removeFile(cacheKey ?? url);
+            yield* Stream.error(e, stackTrace);
+            return;
+          }
           yield decoded;
         }
       }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce?

Bug fix.

### :arrow_heading_down: What is the current behavior?

When a URL returns a successful response but the response body is not valid image data, image decoding fails. The image is evicted from the cache, causing repeated load attempts and continuous progress callbacks instead of reporting the decode error.

### :new: What is the new behavior (if this is a feature change)?

Skip image eviction for decode failures so the error is reported correctly. This prevents repeated load attempts and progress callbacks, allowing the configured `errorWidget` to be displayed.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

* Load a URL that returns a `200 OK` response with invalid image data.
* Verify that the loading progress callback is not repeatedly invoked.
* Verify that the configured `errorWidget` is displayed after the decode failure.
* Verify that valid images continue to load as expected.

### :memo: Links to relevant issues/docs

N/A

### :thinking: Checklist before submitting

* [ ] All projects build
* [ ] Follows style guide lines ([[code style guide](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md)](https://github.com/Baseflow/flutter_cached_network_image/blob/develop/CONTRIBUTING.md))
* [ ] Relevant documentation was updated
* [ ] Rebased onto current develop